### PR TITLE
LIBS-332 Make hmac-sha256 signed upload signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.8 (Apr 22, 2020)
+
+IMPROVEMENTS:
+
+* Use HMAC-SHA256 signature for signed uploads
+* Set upload TTL to 60 seconds
+
 ## 1.1.7 (Apr 14, 2020)
 
 BUG FIXES:

--- a/ucare/auth.go
+++ b/ucare/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/md5"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -93,14 +94,14 @@ func simpleUploadAPIAuthFunc(creds APICreds) UploadAPIAuthFunc {
 
 func signBasedUploadAPIAuthFunc(creds APICreds) UploadAPIAuthFunc {
 	return func() (string, *string, *int64) {
-		exp := time.Now().Add(30 * time.Minute).Unix()
+		exp := time.Now().Add(signedUploadTTL).Unix()
 		sign := signBasedUploadAPIAuthParam(creds.SecretKey, exp)
 		return creds.PublicKey, &sign, &exp
 	}
 }
 
 func signBasedUploadAPIAuthParam(secret string, exp int64) string {
-	h := md5.New()
-	h.Write([]byte(secret + strconv.FormatInt(exp, 10)))
+	h := hmac.New(sha256.New, []byte(secret))
+	_, _ = h.Write([]byte(strconv.FormatInt(exp, 10)))
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/ucare/auth_test.go
+++ b/ucare/auth_test.go
@@ -8,7 +8,7 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func testSimpleAuthRESTAPIParam(t *testing.T) {
+func TestSimpleAuthRESTAPIParam(t *testing.T) {
 	t.Parallel()
 
 	creds := APICreds{
@@ -22,7 +22,7 @@ func testSimpleAuthRESTAPIParam(t *testing.T) {
 	assert.Equal(t, expectedParam, authParam)
 }
 
-func testSignBasedRESTAPIAuthParam(t *testing.T) {
+func TestSignBasedRESTAPIAuthParam(t *testing.T) {
 	creds := APICreds{
 		SecretKey: "demoprivatekey",
 		PublicKey: "testpk",
@@ -47,10 +47,10 @@ func testSignBasedRESTAPIAuthParam(t *testing.T) {
 	assert.Equal(t, expected, authParam)
 }
 
-func testSignBasedUploadAPIAuthParam(t *testing.T) {
+func TestSignBasedUploadAPIAuthParam(t *testing.T) {
 	secret := "project_secret_key"
 	now := int64(1454903856)
-	expected := "46f70d2b4fb6196daeb2c16bf44a7f1e"
+	expected := "d39a461d41f607338abffee5f31da4d4e46535651c87346e76906bf75c064d47"
 
 	assert.Equal(t, expected, signBasedUploadAPIAuthParam(secret, now))
 }

--- a/ucare/config.go
+++ b/ucare/config.go
@@ -13,14 +13,11 @@ const (
 	simpleAuthScheme    = "Uploadcare.Simple"
 	signBasedAuthScheme = "Uploadcare"
 	dateHeaderFormat    = time.RFC1123
+
+	signedUploadTTL = 60 * time.Second
 )
 
 var (
-	supportedVersions = map[string]bool{
-		APIv05: true,
-		APIv06: true,
-	}
-
 	defaultAPIVersion = APIv05
 
 	authHeaderKey      = http.CanonicalHeaderKey("Authorization")


### PR DESCRIPTION
## Description

Make hmac-sha256 signed upload signature
Set signed upload ttl to 60 seconds