### PR TITLE
Fix: incorrect store parameter

### DIFF
--- a/upload/fromurl.go
+++ b/upload/fromurl.go
@@ -20,7 +20,7 @@ type FromURLParams struct {
 	// Valid values are:
 	//	upload.ToStoreTrue
 	//	upload.ToStoreFalse
-	ToStore *string `form:"UPLOADCARE_STORE"`
+	ToStore *string `form:"store"`
 
 	// Name sets the name for a file uploaded from URL. If not defined, the
 	// filename is obtained from either response headers or a source URL


### PR DESCRIPTION
According to API spec, in the `fromURL` method, the parameter that defines storing behavior is `store`. `UPLOADCARE_STORE` is being used in the `direct` method.

https://uploadcare.com/docs/api_reference/upload/from_url/#store
