### PR TITLE
Fix panic when reading FileInfo from response

### DIFF
--- a/upload/fromurl.go
+++ b/upload/fromurl.go
@@ -236,6 +236,17 @@ func (d *fromURLData) wait() {
 
 			switch data.Status {
 			case uploadStatusSuccess:
+				if data == nil || data.FileInfo == nil {
+					err := fmt.Errorf(
+						"no data received: %+v",
+						data,
+					)
+					log.Error(err)
+					if len(d.err) < cap(d.err) {
+						d.err <- err
+					}
+					return
+				}
 				d.done <- *data.FileInfo
 				return
 			case uploadStatusInProgress:

--- a/upload/fromurl.go
+++ b/upload/fromurl.go
@@ -252,11 +252,15 @@ func (d *fromURLData) wait() {
 					"received status: %s, waiting",
 					data.Status,
 				)
-			case uploadStatusUnknown:
-				log.Errorf(
+			default:
+				err := fmt.Sprintf(
 					"received status: %s, aborting",
 					data.Status,
 				)
+				log.Error(err)
+				if len(d.err) < cap(d.err) {
+					d.err <- errors.New(err)
+				}
 				return
 			}
 		}

--- a/upload/service.go
+++ b/upload/service.go
@@ -50,7 +50,7 @@ const (
 	URLDuplicatesTrue  = "1"
 	URLDuplicatesFalse = "0"
 
-	uploadStatuSuccess     = "success"
+	uploadStatusSuccess    = "success"
 	uploadStatusInProgress = "progress"
 	uploadStatusError      = "error"
 	uploadStatusWaiting    = "waiting"


### PR DESCRIPTION
## Description

Addressing panic on `uploadcare-go/upload/fromurl.go:249`: updated response status checking logic.
NOTE: it will still panic if no file info is sent on status ready/success.

Harsh review is welcome here.
