### PR TITLE
[CORE-631] `ContentInfo` field in `File`

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -64,7 +64,7 @@ type BasicFileInfo struct {
 	// VideoMeta holds video metadata
 	VideoMeta *VideoMeta `json:"video_info"`
 
-	// ContentInfo holds information about file content
+	// ContentInfo holds information about file content.
 	// ImageInfo and VideoMeta are duplicates of this data,
 	// left for compatibility.
 	ContentInfo *ContentInfo `json:"content_info"`
@@ -238,12 +238,12 @@ type Mime struct {
 	Subtype string `json:"subtype"`
 }
 
-// VideoInfo hold information about video file and it's streams
+// VideoInfo holds information about video file and its audio and video streams
 type VideoInfo struct {
 	// Duration is a video duration in milliseconds
 	Duration uint64 `json:"duration"`
 
-	// Format is a video format(MP4 for example)
+	// Format is a video format (MP4 for example)
 	Format string `json:"format"`
 
 	// Bitrate is a video bitrate
@@ -256,7 +256,7 @@ type VideoInfo struct {
 	Video []VideoStreamMeta `json:"video"`
 }
 
-// AudioStreamInfo differs from older AudioStreamMeta by having integer `Channels`
+// AudioStreamInfo differs from older AudioStreamMeta by having `Channels` represented as integer
 type AudioStreamInfo struct {
 	// Bitrate holds audio bitrate
 	Bitrate *uint64 `json:"bitrate"`

--- a/file/file.go
+++ b/file/file.go
@@ -241,13 +241,13 @@ type Mime struct {
 // VideoInfo holds information about video file and its audio and video streams
 type VideoInfo struct {
 	// Duration is a video duration in milliseconds
-	Duration uint64 `json:"duration"`
+	Duration *uint64 `json:"duration"`
 
 	// Format is a video format (MP4 for example)
 	Format string `json:"format"`
 
 	// Bitrate is a video bitrate
-	Bitrate uint64 `json:"bitrate"`
+	Bitrate *uint64 `json:"bitrate"`
 
 	// Audio holds audio stream metadata
 	Audio []AudioStreamInfo `json:"audio"`

--- a/file/file.go
+++ b/file/file.go
@@ -64,6 +64,11 @@ type BasicFileInfo struct {
 	// VideoMeta holds video metadata
 	VideoMeta *VideoMeta `json:"video_info"`
 
+	// ContentInfo holds information about file content
+	// ImageInfo and VideoMeta are duplicates of this data,
+	// left for compatibility.
+	ContentInfo *ContentInfo `json:"content_info"`
+
 	// MimeType specifies file MIME-type
 	MimeType string `json:"mime_type"`
 
@@ -217,4 +222,51 @@ type VideoStreamMeta struct {
 type Location struct {
 	Latitude  float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`
+}
+
+// ContentInfo holds information about file content
+type ContentInfo struct {
+	Mime *Mime `json:"mime"`
+	Video *VideoInfo `json:"video"`
+	Image *ImageInfo `json:"image"`
+}
+
+// Mime holds detected and parsed mime type
+type Mime struct {
+	Mime string `json:"mime"`
+	Type string `json:"type"`
+	Subtype string `json:"subtype"`
+}
+
+// VideoInfo hold information about video file and it's streams
+type VideoInfo struct {
+	// Duration is a video duration in milliseconds
+	Duration uint64 `json:"duration"`
+
+	// Format is a video format(MP4 for example)
+	Format string `json:"format"`
+
+	// Bitrate is a video bitrate
+	Bitrate uint64 `json:"bitrate"`
+
+	// Audio holds audio stream metadata
+	Audio []AudioStreamInfo `json:"audio"`
+
+	// Video holds video stream metadata
+	Video []VideoStreamMeta `json:"video"`
+}
+
+// AudioStreamInfo differs from older AudioStreamMeta by having integer `Channels`
+type AudioStreamInfo struct {
+	// Bitrate holds audio bitrate
+	Bitrate *uint64 `json:"bitrate"`
+
+	// Codec holds audio stream codec
+	Codec *string `json:"codec"`
+
+	// SampleRate holds audio stream sample rate
+	SampleRate *uint64 `json:"sample_rate"`
+
+	// Channels holds audio stream number of channels
+	Channels *uint64 `json:"channels"`
 }


### PR DESCRIPTION
## Description

Add new field to struct, so it can be used by webhooks

Recreation of https://github.com/uploadcare/uploadcare-go/pull/12, as source branch cannot be changed and pulling from external repo broke tests.

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
