### PR TITLE
Add REST API v0.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x]
+        go-version: [1.18.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/ucare/config.go
+++ b/ucare/config.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	defaultAPIVersion = APIv05
+	defaultAPIVersion = APIv07
 
 	authHeaderKey      = http.CanonicalHeaderKey("Authorization")
 	userAgentHeaderKey = http.CanonicalHeaderKey("X-UC-User-Agent")

--- a/ucare/config.go
+++ b/ucare/config.go
@@ -9,6 +9,7 @@ import (
 const (
 	APIv05 = "v0.5"
 	APIv06 = "v0.6"
+	APIv07 = "v0.7"
 
 	simpleAuthScheme    = "Uploadcare.Simple"
 	signBasedAuthScheme = "Uploadcare"


### PR DESCRIPTION
## Description

In the current state this SDK does not allow users to benefit from the changes in the REST API v0.7. 

We have recently run into an issue where we added a PDF via a link. The links MIME type was `application/octet-stream` which was saved as the MIME type in Uploadcare. The `ContentInfo` object contains the correct/expected MIME type of `application/pdf`. However, using this SDK we were unable to access these fields since the SDK uses v0.5 by default and v0.6 if configured. 

<!-- Link to the related issue -->

No open issue around this, but I have just encountered an issue with trying to access `file.ContentInfo`.

<!-- Write a brief description of the changes introduced by this PR -->

- Adds configuration support for API v0.7
- Sets the `defaultAPIVersion` to v0.7 from v0.5.

Enables support for new fields added to the REST API since v0.5.

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
