### PR TITLE
Phase 4: SDK gaps for CLI usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ BREAKING CHANGES:
 * Remove `file.OrderBySizeAsc` and `file.OrderBySizeDesc` constants (not supported in v0.7)
 * Remove `APIv05` and `APIv06` constants
 * Minimum Go version is now 1.25
+* Throttled requests no longer retry by default — automatic retries are now opt-in via `ucare.Config.Retry`
 
 FEATURES:
 
@@ -19,12 +20,18 @@ FEATURES:
 * Add `metadata` package with file metadata CRUD operations
 * Add `group.Delete()` for deleting group metadata without deleting files
 * Add webhook event constants for `file.stored`, `file.deleted`, `file.info_updated`, and deprecated `file.infected`
+* Add `ucare.Config.Retry` and `RetryConfig` for configurable throttling retries
+* Add `upload.Service.Upload()` for automatic direct-vs-multipart upload selection
+* Export structured API error types: `APIError`, `AuthError`, `ThrottleError`, `ValidationError`, and `ForbiddenError`
 
 IMPROVEMENTS:
 
 * Add `UserAgent` field to `ucare.Config` for custom agent identification
 * Replace `http.NewRequest` + `WithContext` with `http.NewRequestWithContext`
 * Throttle retry loops now respect context cancellation
+* REST throttling retries now honor `Retry-After` with configurable fail-fast limits and fallback exponential backoff
+* Upload throttling retries now use configurable exponential backoff capping
+* Error values now expose HTTP status details for caller inspection
 * Replace `ioutil` usage with `io` equivalents
 * Replace `go-env` dependency with `os.Getenv`
 * Update `stretchr/testify` to v1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ BREAKING CHANGES:
 * Remove `file.Copy()` method and `file.CopyParams` type — use `LocalCopy()` and `RemoteCopy()`
 * Remove `file.OrderBySizeAsc` and `file.OrderBySizeDesc` constants (not supported in v0.7)
 * Remove `APIv05` and `APIv06` constants
+* Change `file.Service.Info()` signature to accept `*file.InfoParams` for optional `include` query parameters
+* Change `webhook.Service.Delete()` to delete by webhook ID instead of target URL
 * Minimum Go version is now 1.25
 * Throttled requests no longer retry by default — automatic retries are now opt-in via `ucare.Config.Retry`
 
@@ -22,11 +24,16 @@ FEATURES:
 * Add webhook event constants for `file.stored`, `file.deleted`, `file.info_updated`, and deprecated `file.infected`
 * Add `ucare.Config.Retry` and `RetryConfig` for configurable throttling retries
 * Add `upload.Service.Upload()` for automatic direct-vs-multipart upload selection
+* Add upload metadata support for direct, multipart, from-URL, and unified uploads
+* Add `file.InfoParams.Include` and `file.ListParams.Include` for `include=appdata`
+* Add `conversion.Params.SaveInGroup` for document conversions that should persist image output as a file group
+* Add `conversion.BuildDocumentPath()` and `conversion.BuildVideoPath()` helpers for constructing conversion paths
 * Export structured API error types: `APIError`, `AuthError`, `ThrottleError`, `ValidationError`, and `ForbiddenError`
 
 IMPROVEMENTS:
 
 * Add `UserAgent` field to `ucare.Config` for custom agent identification
+* Extend form/query encoding to support Upload API metadata fields in `metadata[key]=value` bracket notation
 * Replace `http.NewRequest` + `WithContext` with `http.NewRequestWithContext`
 * Throttle retry loops now respect context cancellation
 * REST throttling retries now honor `Retry-After` with configurable fail-fast limits and fallback exponential backoff
@@ -37,7 +44,7 @@ IMPROVEMENTS:
 * Update `stretchr/testify` to v1.10.0
 * Update CI: Go 1.25, modern GitHub Actions versions, remove deprecated golint
 * Integration tests skip gracefully when credentials are not set
-* Fix errors in package documentation examples
+* Fix errors in package documentation examples and update public examples for the new `file.Info()` signature
 
 ## 1.2.1 (September 1, 2020)
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Acquiring file-specific info:
 
 ```go
 fileID := ids[0]
-file, err := fileSvc.Info(context.Background(), fileID)
+file, err := fileSvc.Info(context.Background(), fileID, nil)
 if err != nil {
 	// handle error
 }

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -42,6 +42,9 @@ type Params struct {
 	//	conversion.ToStoreTrue
 	//	conversion.ToStoreFalse
 	ToStore *string `json:"store"`
+
+	// SaveInGroup saves a multi-page image conversion result as a file group.
+	SaveInGroup *string `json:"save_in_group,omitempty"`
 }
 
 // EncodeReq implements ucare.ReqEncoder

--- a/conversion/conversion_test.go
+++ b/conversion/conversion_test.go
@@ -1,0 +1,57 @@
+package conversion
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uploadcare/uploadcare-go/v2/ucare"
+)
+
+func TestConversionParams_WithSaveInGroup(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/convert/document/", nil)
+	assert.NoError(t, err)
+
+	params := Params{
+		Paths:       []string{"uuid/document/-/format/png/"},
+		ToStore:     ucare.String(ToStoreTrue),
+		SaveInGroup: ucare.String("1"),
+	}
+
+	err = params.EncodeReq(req)
+	assert.NoError(t, err)
+
+	body, err := io.ReadAll(req.Body)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"paths": ["uuid/document/-/format/png/"],
+		"store": "1",
+		"save_in_group": "1"
+	}`, string(body))
+}
+
+func TestConversionParams_WithoutSaveInGroup(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/convert/document/", nil)
+	assert.NoError(t, err)
+
+	params := Params{
+		Paths:   []string{"uuid/document/-/format/pdf/"},
+		ToStore: ucare.String(ToStoreFalse),
+	}
+
+	err = params.EncodeReq(req)
+	assert.NoError(t, err)
+
+	body, err := io.ReadAll(req.Body)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"paths": ["uuid/document/-/format/pdf/"],
+		"store": "0"
+	}`, string(body))
+	assert.NotContains(t, string(body), "save_in_group")
+}

--- a/conversion/path.go
+++ b/conversion/path.go
@@ -1,0 +1,80 @@
+package conversion
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DocumentPathOptions holds options for building a document conversion path.
+type DocumentPathOptions struct {
+	// UUID is the source file UUID.
+	UUID string
+	// Format is the target document format. Defaults to "pdf" when empty.
+	Format string
+	// Page extracts a single page when greater than zero.
+	Page int
+}
+
+// BuildDocumentPath constructs a document conversion path.
+func BuildDocumentPath(opts DocumentPathOptions) string {
+	format := opts.Format
+	if format == "" {
+		format = "pdf"
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s/document/-/format/%s/", opts.UUID, format)
+
+	if opts.Page > 0 {
+		fmt.Fprintf(&b, "-/page/%d/", opts.Page)
+	}
+
+	return b.String()
+}
+
+// VideoPathOptions holds options for building a video conversion path.
+type VideoPathOptions struct {
+	// UUID is the source file UUID.
+	UUID string
+	// Format is the target video format.
+	Format string
+	// Size is the output dimensions, for example "640x480".
+	Size string
+	// ResizeMode controls how the video is resized.
+	ResizeMode string
+	// Quality controls output quality.
+	Quality string
+	// CutStart is the start time for cutting.
+	CutStart string
+	// CutLength is the duration to cut.
+	CutLength string
+	// Thumbs is the number of thumbnails to generate.
+	Thumbs int
+}
+
+// BuildVideoPath constructs a video conversion path.
+func BuildVideoPath(opts VideoPathOptions) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s/video/-/format/%s/", opts.UUID, opts.Format)
+
+	if opts.Size != "" {
+		fmt.Fprintf(&b, "-/size/%s/", opts.Size)
+		if opts.ResizeMode != "" {
+			fmt.Fprintf(&b, "%s/", opts.ResizeMode)
+		}
+	}
+
+	if opts.Quality != "" {
+		fmt.Fprintf(&b, "-/quality/%s/", opts.Quality)
+	}
+
+	if opts.CutStart != "" && opts.CutLength != "" {
+		fmt.Fprintf(&b, "-/cut/%s/%s/", opts.CutStart, opts.CutLength)
+	}
+
+	if opts.Thumbs > 0 {
+		fmt.Fprintf(&b, "-/thumbs~%d/", opts.Thumbs)
+	}
+
+	return b.String()
+}

--- a/conversion/path_test.go
+++ b/conversion/path_test.go
@@ -1,0 +1,51 @@
+package conversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDocumentPath_FormatOnly(t *testing.T) {
+	t.Parallel()
+
+	path := BuildDocumentPath(DocumentPathOptions{UUID: "abc-123", Format: "pdf"})
+	assert.Equal(t, "abc-123/document/-/format/pdf/", path)
+}
+
+func TestBuildDocumentPath_DefaultFormat(t *testing.T) {
+	t.Parallel()
+
+	path := BuildDocumentPath(DocumentPathOptions{UUID: "abc-123"})
+	assert.Equal(t, "abc-123/document/-/format/pdf/", path)
+}
+
+func TestBuildDocumentPath_WithPage(t *testing.T) {
+	t.Parallel()
+
+	path := BuildDocumentPath(DocumentPathOptions{UUID: "abc-123", Format: "png", Page: 3})
+	assert.Equal(t, "abc-123/document/-/format/png/-/page/3/", path)
+}
+
+func TestBuildVideoPath_Basic(t *testing.T) {
+	t.Parallel()
+
+	path := BuildVideoPath(VideoPathOptions{UUID: "abc-123", Format: "mp4"})
+	assert.Equal(t, "abc-123/video/-/format/mp4/", path)
+}
+
+func TestBuildVideoPath_Full(t *testing.T) {
+	t.Parallel()
+
+	path := BuildVideoPath(VideoPathOptions{
+		UUID:       "abc-123",
+		Format:     "webm",
+		Size:       "640x480",
+		ResizeMode: "preserve_ratio",
+		Quality:    "best",
+		CutStart:   "000:00:05.000",
+		CutLength:  "000:00:15.000",
+		Thumbs:     10,
+	})
+	assert.Equal(t, "abc-123/video/-/format/webm/-/size/640x480/preserve_ratio/-/quality/best/-/cut/000:00:05.000/000:00:15.000/-/thumbs~10/", path)
+}

--- a/file/file.go
+++ b/file/file.go
@@ -6,19 +6,39 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/uploadcare/uploadcare-go/v2/internal/codec"
 	"github.com/uploadcare/uploadcare-go/v2/internal/config"
+	"github.com/uploadcare/uploadcare-go/v2/ucare"
 )
+
+// InfoParams holds optional parameters for the Info method.
+type InfoParams struct {
+	// Include specifies additional fields to include in the response.
+	// Valid value: "appdata".
+	Include *string `form:"include"`
+}
+
+// EncodeReq implements ucare.ReqEncoder.
+func (d *InfoParams) EncodeReq(req *http.Request) error {
+	return codec.EncodeReqQuery(d, req)
+}
 
 // Info acquires some file-specific info
 func (s service) Info(
 	ctx context.Context,
 	fileID string,
+	params *InfoParams,
 ) (data Info, err error) {
+	var reqParams ucare.ReqEncoder
+	if params != nil {
+		reqParams = params
+	}
+
 	err = s.svc.ResourceOp(
 		ctx,
 		http.MethodGet,
 		fmt.Sprintf(infoPathFormat, fileID),
-		nil,
+		reqParams,
 		&data,
 	)
 	return
@@ -222,15 +242,15 @@ type Location struct {
 
 // ContentInfo holds information about file content
 type ContentInfo struct {
-	Mime *Mime `json:"mime"`
+	Mime  *Mime      `json:"mime"`
 	Video *VideoInfo `json:"video"`
 	Image *ImageInfo `json:"image"`
 }
 
 // Mime holds detected and parsed mime type
 type Mime struct {
-	Mime string `json:"mime"`
-	Type string `json:"type"`
+	Mime    string `json:"mime"`
+	Type    string `json:"type"`
 	Subtype string `json:"subtype"`
 }
 

--- a/file/list.go
+++ b/file/list.go
@@ -31,6 +31,10 @@ type ListParams struct {
 	// StartingFrom specifies a starting point for filtering files.
 	// The value depends on your ordering parameter value.
 	StartingFrom *time.Time `form:"from"`
+
+	// Include specifies additional fields to include in the response.
+	// Valid value: "appdata".
+	Include *string `form:"include"`
 }
 
 // EncodeReq implements ucare.ReqEncoder
@@ -65,6 +69,7 @@ func (v *List) ReadResult() (*Info, error) {
 // List returns a list of files.
 //
 // Example usage:
+//
 //	fileList, err := fileSvc.List(ctx, params)
 //	if err != nil {
 //		// handle error

--- a/file/service.go
+++ b/file/service.go
@@ -18,7 +18,7 @@ import (
 // Service describes all file related API
 type Service interface {
 	List(context.Context, ListParams) (*List, error)
-	Info(ctx context.Context, id string) (Info, error)
+	Info(ctx context.Context, id string, params *InfoParams) (Info, error)
 	Store(ctx context.Context, id string) (Info, error)
 	Delete(ctx context.Context, id string) (Info, error)
 	BatchStore(ctx context.Context, ids []string) (BatchInfo, error)

--- a/file/service_test.go
+++ b/file/service_test.go
@@ -1,0 +1,118 @@
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uploadcare/uploadcare-go/v2/internal/config"
+	"github.com/uploadcare/uploadcare-go/v2/ucare"
+)
+
+type testClient struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func (c *testClient) NewRequest(
+	ctx context.Context,
+	_ config.Endpoint,
+	method, requrl string,
+	data ucare.ReqEncoder,
+) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+requrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	if data != nil {
+		if err = data.EncodeReq(req); err != nil {
+			return nil, err
+		}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/vnd.uploadcare-v0.7+json")
+	return req, nil
+}
+
+func (c *testClient) Do(req *http.Request, resdata interface{}) error {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	if resdata == nil || reflect.ValueOf(resdata).IsNil() {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(resdata)
+}
+
+func newTestService(handler http.Handler) (Service, *httptest.Server) {
+	srv := httptest.NewServer(handler)
+	client := &testClient{httpClient: srv.Client(), baseURL: srv.URL}
+	return NewService(client), srv
+}
+
+func TestInfo_WithIncludeAppdata(t *testing.T) {
+	t.Parallel()
+
+	svc, srv := newTestService(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/files/test-uuid/", r.URL.Path)
+		assert.Equal(t, "appdata", r.URL.Query().Get("include"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Info{
+			BasicFileInfo: BasicFileInfo{ID: "test-uuid"},
+		})
+	}))
+	defer srv.Close()
+
+	info, err := svc.Info(context.Background(), "test-uuid", &InfoParams{
+		Include: ucare.String("appdata"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "test-uuid", info.ID)
+}
+
+func TestInfo_NilParams(t *testing.T) {
+	t.Parallel()
+
+	svc, srv := newTestService(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/files/test-uuid/", r.URL.Path)
+		assert.Empty(t, r.URL.RawQuery)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Info{
+			BasicFileInfo: BasicFileInfo{ID: "test-uuid"},
+		})
+	}))
+	defer srv.Close()
+
+	info, err := svc.Info(context.Background(), "test-uuid", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-uuid", info.ID)
+}
+
+func TestListParams_WithInclude(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.test/files/", nil)
+	assert.NoError(t, err)
+
+	err = (&ListParams{Include: ucare.String("appdata")}).EncodeReq(req)
+	assert.NoError(t, err)
+	assert.Equal(t, "appdata", req.URL.Query().Get("include"))
+}

--- a/internal/codec/codec.go
+++ b/internal/codec/codec.go
@@ -111,12 +111,33 @@ func EncodeReqQuery(data interface{}, req *http.Request) error {
 
 	q := req.URL.Query()
 	for i := 0; i < t.NumField(); i++ {
-		f := v.Field(i)
+		tf, f := t.Field(i), v.Field(i)
+		formKey := tf.Tag.Get("form")
+		if formKey == "" {
+			continue
+		}
+
 		if f.Kind() == reflect.Ptr && f.IsNil() {
 			continue
 		}
 
-		q.Set(t.Field(i).Tag.Get("form"), fieldValue(f))
+		if f.Kind() == reflect.Map {
+			if f.IsNil() {
+				continue
+			}
+
+			m, ok := f.Interface().(map[string]string)
+			if !ok {
+				panic(wrongMapType)
+			}
+
+			for k, v := range m {
+				q.Set(fmt.Sprintf("%s[%s]", formKey, k), v)
+			}
+			continue
+		}
+
+		q.Set(formKey, fieldValue(f))
 	}
 	req.URL.RawQuery = q.Encode()
 	return nil
@@ -259,18 +280,28 @@ func writeFormField(
 		return
 	}
 
+	formKey := t.Tag.Get("form")
+
 	if f.Kind() == reflect.Map {
+		if f.IsNil() {
+			return
+		}
+
 		m, ok := f.Interface().(map[string]string)
 		if !ok {
 			panic(wrongMapType)
 		}
+
 		for k, v := range m {
-			w.WriteField(k, v)
+			fieldName := k
+			if formKey != "" {
+				fieldName = fmt.Sprintf("%s[%s]", formKey, k)
+			}
+			_ = w.WriteField(fieldName, v)
 		}
 		return
 	}
 
-	formKey := t.Tag.Get("form")
 	if formKey == "" {
 		return
 	}

--- a/internal/codec/codec_test.go
+++ b/internal/codec/codec_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/uploadcare/uploadcare-go/v2/upload"
 )
 
-func testEncodeReqQuery(t *testing.T) {
+func TestEncodeReqQuery(t *testing.T) {
 	t.Parallel()
 
 	now, _ := time.Parse(config.UCTimeLayout, "2015-04-02T10:00:00")
@@ -27,6 +27,7 @@ func testEncodeReqQuery(t *testing.T) {
 
 		params        interface{}
 		expectedQuery url.Values
+		wantErr       bool
 	}{{
 		test: "full list of params",
 		params: &file.ListParams{
@@ -42,6 +43,14 @@ func testEncodeReqQuery(t *testing.T) {
 			"limit":    []string{"500"},
 			"ordering": []string{"datetime_uploaded"},
 			"from":     []string{"2015-01-02T10:00:00"},
+		},
+	}, {
+		test: "include appdata",
+		params: &file.ListParams{
+			Include: ucare.String("appdata"),
+		},
+		expectedQuery: url.Values{
+			"include": []string{"appdata"},
 		},
 	}, {
 		test:          "empty list",
@@ -62,12 +71,14 @@ func testEncodeReqQuery(t *testing.T) {
 			"stored": ucare.Bool(false),
 		},
 		expectedQuery: url.Values{},
+		wantErr:       true,
 	}, {
 		test: "not struct pointer params type",
 		params: &map[string]*bool{
 			"stored": ucare.Bool(false),
 		},
 		expectedQuery: url.Values{},
+		wantErr:       true,
 	}}
 
 	for _, c := range cases {
@@ -75,8 +86,14 @@ func testEncodeReqQuery(t *testing.T) {
 		t.Run(c.test, func(t *testing.T) {
 			t.Parallel()
 
-			req, _ := http.NewRequest("GET", "", nil)
-			codec.EncodeReqQuery(c.params, req)
+			req, _ := http.NewRequest(http.MethodGet, "https://example.test", nil)
+			err := codec.EncodeReqQuery(c.params, req)
+			if c.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
 			q := req.URL.Query()
 
 			if len(c.expectedQuery) == 0 && req.URL.RawQuery != "" {
@@ -89,7 +106,7 @@ func testEncodeReqQuery(t *testing.T) {
 	}
 }
 
-func testEncodeReqBody(t *testing.T) {
+func TestEncodeReqBody(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -108,8 +125,9 @@ func testEncodeReqBody(t *testing.T) {
 		t.Run(c.test, func(t *testing.T) {
 			t.Parallel()
 
-			req, _ := http.NewRequest("PUT", "", nil)
-			codec.EncodeReqBody(c.params, req)
+			req, _ := http.NewRequest(http.MethodPut, "https://example.test", nil)
+			err := codec.EncodeReqBody(c.params, req)
+			assert.NoError(t, err)
 
 			data, err := io.ReadAll(req.Body)
 			assert.Equal(t, nil, err)
@@ -118,7 +136,7 @@ func testEncodeReqBody(t *testing.T) {
 	}
 }
 
-func testEncodeReqFormData(t *testing.T) {
+func TestEncodeReqFormData(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -174,21 +192,6 @@ func testEncodeReqFormData(t *testing.T) {
 			return nil
 		},
 		err: false,
-	}, {
-		test: "random data holding map",
-		data: &struct {
-			M map[string]string
-		}{
-			M: map[string]string{"key": "testdata"},
-		},
-		testReq: func(written string) error {
-			if !strings.Contains(written, "key") ||
-				!strings.Contains(written, "testdata") {
-				return errors.New("did not work at all")
-			}
-			return nil
-		},
-		err: false,
 	}}
 
 	for _, c := range cases {
@@ -213,4 +216,74 @@ func testEncodeReqFormData(t *testing.T) {
 			assert.Equal(t, nil, c.testReq(string(data)))
 		})
 	}
+}
+
+func TestEncodeReqFormData_WithMetadata(t *testing.T) {
+	t.Parallel()
+
+	body, _, err := codec.EncodeReqFormData(&struct {
+		Metadata map[string]string `form:"metadata"`
+	}{
+		Metadata: map[string]string{
+			"key1": "val1",
+			"key2": "val2",
+		},
+	})
+	assert.NoError(t, err)
+
+	data, err := io.ReadAll(body)
+	assert.NoError(t, err)
+
+	written := string(data)
+	assert.Contains(t, written, `name="metadata[key1]"`)
+	assert.Contains(t, written, "val1")
+	assert.Contains(t, written, `name="metadata[key2]"`)
+	assert.Contains(t, written, "val2")
+}
+
+func TestEncodeReqFormData_NilMetadata(t *testing.T) {
+	t.Parallel()
+
+	body, _, err := codec.EncodeReqFormData(&struct {
+		Metadata map[string]string `form:"metadata"`
+	}{})
+	assert.NoError(t, err)
+
+	data, err := io.ReadAll(body)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "metadata[")
+}
+
+func TestEncodeReqFormData_EmptyMetadata(t *testing.T) {
+	t.Parallel()
+
+	body, _, err := codec.EncodeReqFormData(&struct {
+		Metadata map[string]string `form:"metadata"`
+	}{
+		Metadata: map[string]string{},
+	})
+	assert.NoError(t, err)
+
+	data, err := io.ReadAll(body)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "metadata[")
+}
+
+func TestEncodeReqQuery_WithMetadata(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.test", nil)
+	err := codec.EncodeReqQuery(&struct {
+		Metadata map[string]string `form:"metadata"`
+	}{
+		Metadata: map[string]string{
+			"key1": "val1",
+			"key2": "val2",
+		},
+	}, req)
+	assert.NoError(t, err)
+
+	q := req.URL.Query()
+	assert.Equal(t, "val1", q.Get("metadata[key1]"))
+	assert.Equal(t, "val2", q.Get("metadata[key2]"))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,8 +19,6 @@ const (
 
 	AcceptHeaderFormat = "application/vnd.uploadcare-%s+json"
 
-	MaxThrottleRetries = 3
-
 	UCTimeLayout = "2006-01-02T15:04:05"
 )
 

--- a/test/file.go
+++ b/test/file.go
@@ -27,7 +27,7 @@ func listFiles(t *testing.T, r *testenv.Runner) {
 
 func fileInfo(t *testing.T, r *testenv.Runner) {
 	ctx := context.Background()
-	info, err := r.File.Info(ctx, r.Artifacts.Files[0].ID)
+	info, err := r.File.Info(ctx, r.Artifacts.Files[0].ID, nil)
 	assert.Equal(t, nil, err)
 	assert.Equal(
 		t,

--- a/test/webhook.go
+++ b/test/webhook.go
@@ -68,6 +68,6 @@ func webhookList(t *testing.T, r *testenv.Runner) {
 }
 
 func webhookDelete(t *testing.T, r *testenv.Runner) {
-	err := r.Webhook.Delete(context.Background(), webhookURL)
+	err := r.Webhook.Delete(context.Background(), r.Artifacts.Webhook.ID)
 	assert.Equal(t, nil, err)
 }

--- a/ucare/client.go
+++ b/ucare/client.go
@@ -40,6 +40,9 @@ type Config struct {
 	// UserAgent is appended to the default User-Agent string.
 	// Use this to identify your application (e.g. "my-app/1.0.0").
 	UserAgent string
+	// Retry controls automatic retry of throttled (HTTP 429) requests.
+	// When nil (the default), throttled requests fail immediately.
+	Retry *RetryConfig
 }
 
 // ReqEncoder exists to encode data into the prepared request.

--- a/ucare/client.go
+++ b/ucare/client.go
@@ -42,6 +42,7 @@ type Config struct {
 	UserAgent string
 	// Retry controls automatic retry of throttled (HTTP 429) requests.
 	// When nil (the default), throttled requests fail immediately.
+	// See RetryConfig for REST vs. Upload API differences in MaxWaitSeconds.
 	Retry *RetryConfig
 }
 

--- a/ucare/doc.go
+++ b/ucare/doc.go
@@ -55,7 +55,7 @@ Getting a list of files:
 Acquiring file-specific info:
 
 	fileID := ids[0]
-	file, err := fileSvc.Info(context.Background(), fileID)
+	file, err := fileSvc.Info(context.Background(), fileID, nil)
 	if err != nil {
 		// handle error
 	}
@@ -133,6 +133,5 @@ Uploading a file
 	if err != nil {
 		// handle error
 	}
-
 */
 package ucare

--- a/ucare/error.go
+++ b/ucare/error.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// API response errors
+// Sentinel errors for specific conditions
 var (
 	ErrInvalidAuthCreds = errors.New("Incorrect authentication credentials")
 	ErrAuthForbidden    = errors.New("Simple authentication over HTTP is " +
@@ -18,43 +18,50 @@ var (
 		"files smaller than 100MB")
 )
 
-type respErr struct {
-	Details string `json:"detail"`
+// APIError represents a generic API error response.
+// Callers can use errors.As to check for this type as a catch-all
+// for any non-specific API error.
+type APIError struct {
+	StatusCode int    `json:"-"`
+	Detail     string `json:"detail"`
 }
 
-// Error implements error interface
-func (e respErr) Error() string {
-	return e.Details
+func (e APIError) Error() string {
+	return fmt.Sprintf("uploadcare: HTTP %d: %s", e.StatusCode, e.Detail)
 }
 
-type authErr struct{ respErr }
+// AuthError represents an authentication failure (HTTP 401).
+type AuthError struct{ APIError }
 
-type throttleErr struct {
+func (e AuthError) Error() string {
+	return fmt.Sprintf("uploadcare: authentication failed: %s", e.Detail)
+}
+
+// ThrottleError represents a throttled request (HTTP 429).
+type ThrottleError struct {
 	RetryAfter int
 }
 
-func (e throttleErr) Error() string {
+func (e ThrottleError) Error() string {
 	if e.RetryAfter == 0 {
-		return "Request was throttled."
+		return "uploadcare: request throttled"
 	}
 	return fmt.Sprintf(
-		"Request was throttled. Expected available in %d second",
+		"uploadcare: request throttled, retry after %d seconds",
 		e.RetryAfter,
 	)
 }
 
-type reqValidationErr struct{ respErr }
+// ValidationError represents a request validation failure (HTTP 400).
+type ValidationError struct{ APIError }
 
-func (e reqValidationErr) Error() string {
-	return fmt.Sprintf("Request parameters validation error: %s", e.Details)
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("uploadcare: validation error: %s", e.Detail)
 }
 
-type reqForbiddenErr struct{ respErr }
+// ForbiddenError represents a forbidden request (HTTP 403).
+type ForbiddenError struct{ APIError }
 
-type unexpectedStatusErr struct {
-	StatusCode int
-}
-
-func (e unexpectedStatusErr) Error() string {
-	return fmt.Sprintf("unexpected HTTP status: %d", e.StatusCode)
+func (e ForbiddenError) Error() string {
+	return fmt.Sprintf("uploadcare: forbidden: %s", e.Detail)
 }

--- a/ucare/error_test.go
+++ b/ucare/error_test.go
@@ -1,0 +1,94 @@
+package ucare
+
+import (
+	"errors"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestAPIError_Error(t *testing.T) {
+	t.Parallel()
+	err := APIError{StatusCode: 404, Detail: "not found"}
+	assert.Equal(t, "uploadcare: HTTP 404: not found", err.Error())
+}
+
+func TestAuthError_Error(t *testing.T) {
+	t.Parallel()
+	err := AuthError{APIError{StatusCode: 401, Detail: "invalid token"}}
+	assert.Equal(t, "uploadcare: authentication failed: invalid token", err.Error())
+}
+
+func TestThrottleError_Error(t *testing.T) {
+	t.Parallel()
+	err := ThrottleError{RetryAfter: 5}
+	assert.Equal(t, "uploadcare: request throttled, retry after 5 seconds", err.Error())
+}
+
+func TestThrottleError_Error_ZeroRetryAfter(t *testing.T) {
+	t.Parallel()
+	err := ThrottleError{}
+	assert.Equal(t, "uploadcare: request throttled", err.Error())
+}
+
+func TestValidationError_Error(t *testing.T) {
+	t.Parallel()
+	err := ValidationError{APIError{StatusCode: 400, Detail: "bad field"}}
+	assert.Equal(t, "uploadcare: validation error: bad field", err.Error())
+}
+
+func TestForbiddenError_Error(t *testing.T) {
+	t.Parallel()
+	err := ForbiddenError{APIError{StatusCode: 403, Detail: "denied"}}
+	assert.Equal(t, "uploadcare: forbidden: denied", err.Error())
+}
+
+func TestErrorsAs_APIError(t *testing.T) {
+	t.Parallel()
+	var target APIError
+	err := error(APIError{StatusCode: 409, Detail: "conflict"})
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, 409, target.StatusCode)
+}
+
+func TestErrorsAs_AuthError(t *testing.T) {
+	t.Parallel()
+	var target AuthError
+	err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, 401, target.StatusCode)
+}
+
+func TestErrorsAs_ThrottleError(t *testing.T) {
+	t.Parallel()
+	var target ThrottleError
+	err := error(ThrottleError{RetryAfter: 10})
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, 10, target.RetryAfter)
+}
+
+func TestErrorsAs_AuthError_DoesNotMatchAPIError(t *testing.T) {
+	t.Parallel()
+	var target APIError
+	err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
+	// AuthError embeds APIError as a value, not a pointer.
+	// errors.As does not unwrap embedded value types, so this does NOT match.
+	// Callers should check specific types first, then APIError as fallback.
+	assert.False(t, errors.As(err, &target))
+}
+
+func TestErrorsAs_ValidationError(t *testing.T) {
+	t.Parallel()
+	var target ValidationError
+	err := error(ValidationError{APIError{StatusCode: 400, Detail: "bad input"}})
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, 400, target.StatusCode)
+}
+
+func TestErrorsAs_ForbiddenError(t *testing.T) {
+	t.Parallel()
+	var target ForbiddenError
+	err := error(ForbiddenError{APIError{StatusCode: 403, Detail: "no"}})
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, 403, target.StatusCode)
+}

--- a/ucare/restapi.go
+++ b/ucare/restapi.go
@@ -171,6 +171,8 @@ func (c *restAPIClient) handleResponse(
 		}
 		wait := retryAfter
 		if wait <= 0 {
+			// Without a usable Retry-After from the server, REST retries fall
+			// back to exponential backoff instead of applying MaxWaitSeconds.
 			wait = expBackoff(tries)
 		}
 		select {

--- a/ucare/restapi.go
+++ b/ucare/restapi.go
@@ -22,7 +22,8 @@ type restAPIClient struct {
 	acceptHeader  string
 	setAuthHeader restAPIAuthFunc
 
-	conn *http.Client
+	conn  *http.Client
+	retry *RetryConfig
 }
 
 func newRESTAPIClient(creds APICreds, conf *Config) Client {
@@ -32,7 +33,8 @@ func newRESTAPIClient(creds APICreds, conf *Config) Client {
 
 		setAuthHeader: simpleRESTAPIAuth,
 
-		conn: conf.HTTPClient,
+		conn:  conf.HTTPClient,
+		retry: conf.Retry,
 	}
 
 	if conf.SignBasedAuthentication {
@@ -131,17 +133,26 @@ func (c *restAPIClient) handleResponse(
 
 	switch resp.StatusCode {
 	case 400, 404:
-		var err respErr
-		if e := json.NewDecoder(resp.Body).Decode(&err); e != nil {
+		var apiErr APIError
+		if e := json.NewDecoder(resp.Body).Decode(&apiErr); e != nil {
 			return false, e
 		}
-		return false, err
+		apiErr.StatusCode = resp.StatusCode
+		return false, apiErr
 	case 401:
-		var err authErr
-		if e := json.NewDecoder(resp.Body).Decode(&err); e != nil {
+		var authErr AuthError
+		if e := json.NewDecoder(resp.Body).Decode(&authErr); e != nil {
 			return false, e
 		}
-		return false, err
+		authErr.StatusCode = 401
+		return false, authErr
+	case 403:
+		var forbiddenErr ForbiddenError
+		if e := json.NewDecoder(resp.Body).Decode(&forbiddenErr); e != nil {
+			return false, e
+		}
+		forbiddenErr.StatusCode = 403
+		return false, forbiddenErr
 	case 406:
 		return false, ErrInvalidVersion
 	case 429:
@@ -149,25 +160,32 @@ func (c *restAPIClient) handleResponse(
 			resp.Header.Get("Retry-After"),
 		)
 		if err != nil {
-			return false, fmt.Errorf("invalid Retry-After: %w", err)
+			retryAfter = 0
 		}
-
-		if tries > config.MaxThrottleRetries {
-			return false, throttleErr{retryAfter}
+		if c.retry == nil || tries > c.retry.MaxRetries {
+			return false, ThrottleError{RetryAfter: retryAfter}
 		}
-
+		if c.retry.MaxWaitSeconds > 0 &&
+			retryAfter > c.retry.MaxWaitSeconds {
+			return false, ThrottleError{RetryAfter: retryAfter}
+		}
+		wait := retryAfter
+		if wait <= 0 {
+			wait = expBackoff(tries)
+		}
 		select {
 		case <-req.Context().Done():
 			return false, req.Context().Err()
-		case <-time.After(time.Duration(retryAfter) * time.Second):
+		case <-time.After(time.Duration(wait) * time.Second):
 		}
 		return true, nil
 	default:
 		if resp.StatusCode >= 400 {
-			var apiErr respErr
-			if e := json.NewDecoder(resp.Body).Decode(&apiErr); e != nil || apiErr.Details == "" {
-				return false, unexpectedStatusErr{StatusCode: resp.StatusCode}
+			var apiErr APIError
+			if e := json.NewDecoder(resp.Body).Decode(&apiErr); e != nil || apiErr.Detail == "" {
+				apiErr.Detail = http.StatusText(resp.StatusCode)
 			}
+			apiErr.StatusCode = resp.StatusCode
 			return false, apiErr
 		}
 	}

--- a/ucare/restapi_test.go
+++ b/ucare/restapi_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -130,9 +131,10 @@ func TestDo_UnhandledStatusWithDetail(t *testing.T) {
 	err = client.Do(req, &result)
 
 	assert.Error(t, err)
-	var apiErr respErr
+	var apiErr APIError
 	assert.True(t, errors.As(err, &apiErr))
-	assert.Equal(t, "Addon is already running for this file.", apiErr.Details)
+	assert.Equal(t, http.StatusConflict, apiErr.StatusCode)
+	assert.Equal(t, "Addon is already running for this file.", apiErr.Detail)
 	assert.Equal(t, "", result.RequestID)
 }
 
@@ -153,9 +155,33 @@ func TestDo_UnhandledStatusWithoutDetail(t *testing.T) {
 	err = client.Do(req, &result)
 
 	assert.Error(t, err)
-	var statusErr unexpectedStatusErr
-	assert.True(t, errors.As(err, &statusErr))
-	assert.Equal(t, http.StatusBadGateway, statusErr.StatusCode)
+	var apiErr APIError
+	assert.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
+	assert.Equal(t, "Bad Gateway", apiErr.Detail)
+}
+
+func TestDo_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"detail":"Account is inactive."}`))
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{conn: srv.Client()}
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var forbiddenErr ForbiddenError
+	assert.True(t, errors.As(err, &forbiddenErr))
+	assert.Equal(t, 403, forbiddenErr.StatusCode)
+	assert.Equal(t, "Account is inactive.", forbiddenErr.Detail)
 }
 
 func TestDo_UnhandledStatusNilResdata(t *testing.T) {
@@ -203,4 +229,143 @@ func TestDo_SuccessNilResdataClosesBody(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.True(t, closed)
+}
+
+func TestDo_ThrottleNoRetryByDefault(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{conn: srv.Client()}
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var throttleErr ThrottleError
+	assert.True(t, errors.As(err, &throttleErr))
+	assert.Equal(t, 1, throttleErr.RetryAfter)
+	assert.Equal(t, int32(1), count.Load())
+}
+
+func TestDo_ThrottleRetrySuccess(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := count.Add(1)
+		if n < 3 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{
+		conn:  srv.Client(),
+		retry: &RetryConfig{MaxRetries: 3},
+	}
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	var result map[string]bool
+	err = client.Do(req, &result)
+
+	assert.NoError(t, err)
+	assert.True(t, result["ok"])
+	assert.Equal(t, int32(3), count.Load())
+}
+
+func TestDo_ThrottleRetriesExhausted(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{
+		conn:  srv.Client(),
+		retry: &RetryConfig{MaxRetries: 2},
+	}
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var throttleErr ThrottleError
+	assert.True(t, errors.As(err, &throttleErr))
+	// 1st request + 2 retries = 3 total, then on 3rd retry (tries=3) tries > MaxRetries(2)
+	assert.Equal(t, int32(3), count.Load())
+}
+
+func TestDo_ThrottleMaxWaitExceeded(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{
+		conn:  srv.Client(),
+		retry: &RetryConfig{MaxRetries: 3, MaxWaitSeconds: 1},
+	}
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	start := time.Now()
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var throttleErr ThrottleError
+	assert.True(t, errors.As(err, &throttleErr))
+	assert.Equal(t, 60, throttleErr.RetryAfter)
+	assert.Equal(t, int32(1), count.Load())
+	// The server requested 60s; the client should fail fast instead of retrying.
+	assert.Less(t, time.Since(start).Seconds(), 5.0)
+}
+
+func TestDo_ThrottleContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{
+		conn:  srv.Client(),
+		retry: &RetryConfig{MaxRetries: 3},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
 }

--- a/ucare/retry.go
+++ b/ucare/retry.go
@@ -1,0 +1,20 @@
+package ucare
+
+// RetryConfig controls automatic retry of throttled (HTTP 429) requests.
+// When nil in Config (the default), throttled requests fail immediately.
+type RetryConfig struct {
+	// MaxRetries is the maximum number of retry attempts.
+	// 0 means no retries even if RetryConfig is set.
+	MaxRetries int
+	// MaxWaitSeconds caps retry waits.
+	// For REST requests, a positive Retry-After above this cap fails fast.
+	// For upload requests, locally computed backoff is clamped to this cap.
+	// 0 means no cap.
+	MaxWaitSeconds int
+}
+
+// expBackoff returns exponential backoff wait: 1, 2, 4, 8... capped at 30s.
+func expBackoff(attempt int) int {
+	wait := 1 << (attempt - 1)
+	return min(wait, 30)
+}

--- a/ucare/retry.go
+++ b/ucare/retry.go
@@ -6,9 +6,14 @@ type RetryConfig struct {
 	// MaxRetries is the maximum number of retry attempts.
 	// 0 means no retries even if RetryConfig is set.
 	MaxRetries int
-	// MaxWaitSeconds caps retry waits.
-	// For REST requests, a positive Retry-After above this cap fails fast.
-	// For upload requests, locally computed backoff is clamped to this cap.
+	// MaxWaitSeconds limits retry waits, but the exact behavior depends on
+	// which API returned HTTP 429:
+	//   - REST API: if the server sends a positive Retry-After above this
+	//     value, the request fails fast with ThrottleError instead of retrying.
+	//     Fallback exponential backoff used when Retry-After is absent or
+	//     invalid is not capped by this field.
+	//   - Upload API: locally computed exponential backoff is clamped to this
+	//     value because the upload API does not return Retry-After.
 	// 0 means no cap.
 	MaxWaitSeconds int
 }

--- a/ucare/retry_test.go
+++ b/ucare/retry_test.go
@@ -1,0 +1,29 @@
+package ucare
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestExpBackoff(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		attempt int
+		want    int
+	}{
+		{1, 1},
+		{2, 2},
+		{3, 4},
+		{4, 8},
+		{5, 16},
+		{6, 30}, // capped
+		{7, 30},
+		{10, 30},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, expBackoff(c.attempt), "attempt %d", c.attempt)
+	}
+}

--- a/ucare/uploadapi.go
+++ b/ucare/uploadapi.go
@@ -155,7 +155,7 @@ func (c *uploadAPIClient) handleResponse(
 		return false, nil
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&resdata); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(resdata); err != nil {
 		return false, err
 	}
 

--- a/ucare/uploadapi.go
+++ b/ucare/uploadapi.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"time"
 
 	"github.com/uploadcare/uploadcare-go/v2/internal/config"
@@ -15,13 +14,15 @@ import (
 type uploadAPIClient struct {
 	authFunc UploadAPIAuthFunc
 
-	conn *http.Client
+	conn  *http.Client
+	retry *RetryConfig
 }
 
 func newUploadAPIClient(creds APICreds, conf *Config) Client {
 	c := uploadAPIClient{
 		authFunc: simpleUploadAPIAuthFunc(creds),
 		conn:     conf.HTTPClient,
+		retry:    conf.Retry,
 	}
 
 	if conf.SignBasedAuthentication {
@@ -70,67 +71,93 @@ func (c *uploadAPIClient) Do(
 	req *http.Request,
 	resdata interface{},
 ) error {
-	tries := 0
-try:
-	tries++
+	for tries := 1; ; tries++ {
+		if tries > 1 && req.GetBody != nil {
+			var err error
+			req.Body, err = req.GetBody()
+			if err != nil {
+				return err
+			}
+		}
 
-	if tries > 1 && req.GetBody != nil {
-		var err error
-		req.Body, err = req.GetBody()
+		log.Debugf("making %d request: %s %+v", tries, req.Method, req.URL)
+
+		resp, err := c.conn.Do(req)
 		if err != nil {
 			return err
 		}
-	}
 
-	log.Debugf("making %d request: %s %+v", tries, req.Method, req.URL)
+		retry, err := c.handleResponse(resp, resdata, tries)
+		if err != nil || !retry {
+			return err
+		}
+	}
+}
 
-	resp, err := c.conn.Do(req)
-	if err != nil {
-		return err
-	}
-	if req.Body != nil {
-		defer req.Body.Close()
-	}
+func (c *uploadAPIClient) handleResponse(
+	resp *http.Response,
+	resdata interface{},
+	tries int,
+) (bool, error) {
+	defer resp.Body.Close()
 
 	log.Debugf("received response: %+v", resp)
 
 	switch resp.StatusCode {
-	case 400, 403:
+	case 400:
 		data, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return err
+			return false, err
 		}
-		resp.Body.Close()
-		switch resp.StatusCode {
-		case 400:
-			return reqValidationErr{respErr{string(data)}}
-		case 403:
-			return reqForbiddenErr{respErr{string(data)}}
+		return false, ValidationError{APIError{StatusCode: 400, Detail: string(data)}}
+	case 403:
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
 		}
+		return false, ForbiddenError{APIError{StatusCode: 403, Detail: string(data)}}
 	case 413:
-		return ErrFileTooLarge
+		return false, ErrFileTooLarge
 	case 429:
-		if tries > config.MaxThrottleRetries {
-			return throttleErr{}
+		if c.retry == nil || tries > c.retry.MaxRetries {
+			return false, ThrottleError{}
 		}
-		// retry after is not returned from the upload API
+		wait := expBackoff(tries)
+		if c.retry.MaxWaitSeconds > 0 && wait > c.retry.MaxWaitSeconds {
+			wait = c.retry.MaxWaitSeconds
+		}
 		select {
-		case <-req.Context().Done():
-			return req.Context().Err()
-		case <-time.After(5 * time.Second):
+		case <-resp.Request.Context().Done():
+			return false, resp.Request.Context().Err()
+		case <-time.After(time.Duration(wait) * time.Second):
 		}
-		goto try
+		return true, nil
 	default:
+		if resp.StatusCode >= 400 {
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return false, err
+			}
+			var apiErr APIError
+			if json.Unmarshal(body, &apiErr) != nil || apiErr.Detail == "" {
+				detail := string(body)
+				if detail == "" {
+					detail = http.StatusText(resp.StatusCode)
+				}
+				apiErr.Detail = detail
+			}
+			apiErr.StatusCode = resp.StatusCode
+			return false, apiErr
+		}
 	}
 
-	if resdata == nil || reflect.ValueOf(resdata).IsNil() {
-		return nil
+	if isNilResponseData(resdata) {
+		return false, nil
 	}
-	err = json.NewDecoder(resp.Body).Decode(&resdata)
-	if err != nil {
-		return err
-	}
-	resp.Body.Close()
 
-	return nil
+	if err := json.NewDecoder(resp.Body).Decode(&resdata); err != nil {
+		return false, err
+	}
+
+	return false, nil
 }

--- a/ucare/uploadapi_test.go
+++ b/ucare/uploadapi_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -64,4 +66,79 @@ func TestUploadAPIClient(t *testing.T) {
 			assert.Equal(t, nil, c.checkReq(req))
 		})
 	}
+}
+
+func TestUploadDo_ThrottleNoRetryByDefault(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := &uploadAPIClient{conn: srv.Client()}
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var throttleErr ThrottleError
+	assert.True(t, errors.As(err, &throttleErr))
+	assert.Equal(t, int32(1), count.Load())
+}
+
+func TestUploadDo_ThrottleRetrySuccess(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := count.Add(1)
+		if n < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"file":"test-id"}`))
+	}))
+	defer srv.Close()
+
+	client := &uploadAPIClient{
+		conn:  srv.Client(),
+		retry: &RetryConfig{MaxRetries: 3},
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+	assert.NoError(t, err)
+
+	var result map[string]string
+	err = client.Do(req, &result)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "test-id", result["file"])
+	assert.Equal(t, int32(2), count.Load())
+}
+
+func TestUploadDo_UnhandledStatusPlainTextBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		w.Write([]byte("upstream connect error"))
+	}))
+	defer srv.Close()
+
+	client := &uploadAPIClient{conn: srv.Client()}
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var apiErr APIError
+	assert.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
+	assert.Equal(t, "upstream connect error", apiErr.Detail)
 }

--- a/ucare/uploadapi_test.go
+++ b/ucare/uploadapi_test.go
@@ -2,6 +2,7 @@ package ucare
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -119,6 +120,28 @@ func TestUploadDo_ThrottleRetrySuccess(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "test-id", result["file"])
 	assert.Equal(t, int32(2), count.Load())
+}
+
+func TestUploadDo_SuccessRequiresPointerResdata(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"file":"test-id"}`))
+	}))
+	defer srv.Close()
+
+	client := &uploadAPIClient{conn: srv.Client()}
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+	assert.NoError(t, err)
+
+	result := map[string]string{}
+	err = client.Do(req, result)
+
+	assert.Error(t, err)
+	var invalidUnmarshal *json.InvalidUnmarshalError
+	assert.True(t, errors.As(err, &invalidUnmarshal))
 }
 
 func TestUploadDo_UnhandledStatusPlainTextBody(t *testing.T) {

--- a/upload/direct.go
+++ b/upload/direct.go
@@ -35,6 +35,9 @@ type FileParams struct {
 	//	upload.ToStoreFalse
 	//	upload.ToStoreAuto
 	ToStore *string `form:"UPLOADCARE_STORE"`
+
+	// Metadata stores user-defined key-value pairs with the uploaded file.
+	Metadata map[string]string `form:"metadata"`
 }
 
 type uploadFileAuthParams struct {

--- a/upload/fromurl.go
+++ b/upload/fromurl.go
@@ -44,6 +44,9 @@ type FromURLParams struct {
 	//	upload.URLDuplicatesTrue
 	//	upload.URLDuplicatesFalse
 	SaveURLDuplicates *string `form:"save_URL_duplicates"`
+
+	// Metadata stores user-defined key-value pairs with the uploaded file.
+	Metadata map[string]string `form:"metadata"`
 }
 
 type fromURLAuthParams struct {
@@ -185,6 +188,7 @@ func (d *fromURLData) Info() (FileInfo, bool) {
 
 // Done is used to wait for uploading to be done. If uploading fails it will
 // never receive FileInfo value:
+//
 //	select {
 //	case fileinfo := <-res.Done():
 //		// file info received

--- a/upload/multipart.go
+++ b/upload/multipart.go
@@ -34,6 +34,9 @@ type MultipartParams struct {
 	//	upload.ToStoreFalse
 	//	upload.ToStoreAuto
 	ToStore *string `form:"UPLOADCARE_STORE"`
+
+	// Metadata stores user-defined key-value pairs with the uploaded file.
+	Metadata map[string]string `form:"metadata"`
 }
 
 type multipartAuthParams struct {
@@ -251,6 +254,7 @@ func (d partEncoder) EncodeReq(req *http.Request) error {
 
 // Done is used to wait for uploading to be done. If uploading fails it will
 // never receive FileInfo value:
+//
 //	select {
 //	case fileinfo := <-res.Done():
 //		// file info received

--- a/upload/service.go
+++ b/upload/service.go
@@ -26,6 +26,7 @@ import (
 
 // Service describes all upload related API functionality
 type Service interface {
+	Upload(context.Context, UploadParams) (FileInfo, error)
 	File(context.Context, FileParams) (id string, err error)
 	FromURL(context.Context, FromURLParams) (FromURLData, error)
 	FileInfo(ctx context.Context, id string) (FileInfo, error)

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -1,0 +1,89 @@
+package upload
+
+import (
+	"context"
+	"io"
+)
+
+// DefaultMultipartThreshold is the default file size threshold for switching
+// from direct upload to multipart upload. Files larger than this value
+// will use multipart upload.
+const DefaultMultipartThreshold int64 = 10 * 1024 * 1024 // 10MB
+
+// UploadParams holds parameters for the unified Upload method.
+type UploadParams struct {
+	// Data (required) reads the data to be uploaded.
+	Data io.ReadSeeker
+	// Name (required) is the original filename.
+	Name string
+	// ContentType is the file MIME-type.
+	ContentType string
+	// Size (required) is the precise file size in bytes.
+	Size int64
+	// ToStore sets the file storing behaviour.
+	ToStore *string
+	// MultipartThreshold controls the upload method selection:
+	//   nil    → use DefaultMultipartThreshold (10MB)
+	//   > 0   → use as custom threshold
+	//   0     → force direct upload
+	//   < 0   → force multipart upload
+	MultipartThreshold *int64
+}
+
+// Upload automatically selects direct or multipart upload based on file size
+// and the configured threshold. It returns a FileInfo for the uploaded file.
+func (s service) Upload(ctx context.Context, params UploadParams) (FileInfo, error) {
+	threshold := DefaultMultipartThreshold
+	if params.MultipartThreshold != nil {
+		threshold = *params.MultipartThreshold
+	}
+
+	useMultipart := false
+	if threshold < 0 {
+		useMultipart = true
+	} else if threshold == 0 {
+		useMultipart = false
+	} else {
+		useMultipart = params.Size > threshold
+	}
+
+	if useMultipart {
+		return s.uploadMultipart(ctx, params)
+	}
+	return s.uploadDirect(ctx, params)
+}
+
+func (s service) uploadDirect(ctx context.Context, params UploadParams) (FileInfo, error) {
+	id, err := s.File(ctx, FileParams{
+		Data:        params.Data,
+		Name:        params.Name,
+		ContentType: params.ContentType,
+		ToStore:     params.ToStore,
+	})
+	if err != nil {
+		return FileInfo{}, err
+	}
+	return s.FileInfo(ctx, id)
+}
+
+func (s service) uploadMultipart(ctx context.Context, params UploadParams) (FileInfo, error) {
+	data, err := s.Multipart(ctx, MultipartParams{
+		Data:        params.Data,
+		FileName:    params.Name,
+		ContentType: params.ContentType,
+		Size:        params.Size,
+		ToStore:     params.ToStore,
+	})
+	if err != nil {
+		return FileInfo{}, err
+	}
+
+	select {
+	case info := <-data.Done():
+		return info, nil
+	case err := <-data.Error():
+		return FileInfo{}, err
+	case <-ctx.Done():
+		return FileInfo{}, ctx.Err()
+	}
+}

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -22,6 +22,8 @@ type UploadParams struct {
 	Size int64
 	// ToStore sets the file storing behaviour.
 	ToStore *string
+	// Metadata stores user-defined key-value pairs with the uploaded file.
+	Metadata map[string]string
 	// MultipartThreshold controls the upload method selection:
 	//   nil    → use DefaultMultipartThreshold (10MB)
 	//   > 0   → use as custom threshold
@@ -59,6 +61,7 @@ func (s service) uploadDirect(ctx context.Context, params UploadParams) (FileInf
 		Name:        params.Name,
 		ContentType: params.ContentType,
 		ToStore:     params.ToStore,
+		Metadata:    params.Metadata,
 	})
 	if err != nil {
 		return FileInfo{}, err
@@ -73,6 +76,7 @@ func (s service) uploadMultipart(ctx context.Context, params UploadParams) (File
 		ContentType: params.ContentType,
 		Size:        params.Size,
 		ToStore:     params.ToStore,
+		Metadata:    params.Metadata,
 	})
 	if err != nil {
 		return FileInfo{}, err

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -311,4 +313,81 @@ func TestUpload_ForceMultipartUpload(t *testing.T) {
 	assert.Equal(t, "forced-multi.txt", info.FileName)
 	assert.Equal(t, int32(0), directHit.Load())
 	assert.Equal(t, int32(1), multipartHit.Load())
+}
+
+func TestUpload_MetadataPassThrough_DirectUpload(t *testing.T) {
+	t.Parallel()
+
+	fileID := "test-uuid-metadata-direct"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.Contains(t, string(body), `name="metadata[source]"`)
+			assert.Contains(t, string(body), "cli")
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/info/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "meta.txt"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data:     strings.NewReader("hi"),
+		Name:     "meta.txt",
+		Size:     2,
+		Metadata: map[string]string{"source": "cli"},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "meta.txt", info.FileName)
+}
+
+func TestUpload_MetadataPassThrough_MultipartUpload(t *testing.T) {
+	t.Parallel()
+
+	fileID := "test-uuid-metadata-multipart"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/multipart/start/":
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.Contains(t, string(body), `name="metadata[source]"`)
+			assert.Contains(t, string(body), "cli")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":  fileID,
+				"parts": []string{},
+			})
+		case "/multipart/complete/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "meta-multi.txt"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data:               bytes.NewReader([]byte("hello")),
+		Name:               "meta-multi.txt",
+		ContentType:        "text/plain",
+		Size:               5,
+		Metadata:           map[string]string{"source": "cli"},
+		MultipartThreshold: int64Ptr(-1),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "meta-multi.txt", info.FileName)
 }

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -1,0 +1,313 @@
+package upload
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	"github.com/uploadcare/uploadcare-go/v2/internal/config"
+	"github.com/uploadcare/uploadcare-go/v2/ucare"
+)
+
+type mockUploadClient struct {
+	baseURL string
+	conn    *http.Client
+}
+
+func (c *mockUploadClient) NewRequest(
+	ctx context.Context,
+	_ config.Endpoint,
+	method string,
+	requrl string,
+	data ucare.ReqEncoder,
+) (*http.Request, error) {
+	fullURL := c.baseURL + requrl
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	ctx = context.WithValue(ctx, config.CtxAuthFuncKey, ucare.UploadAPIAuthFunc(
+		func() (string, *string, *int64) {
+			return "testpubkey", nil, nil
+		},
+	))
+	req = req.WithContext(ctx)
+	if data != nil {
+		if err := data.EncodeReq(req); err != nil {
+			return nil, err
+		}
+	}
+	return req, nil
+}
+
+func (c *mockUploadClient) Do(req *http.Request, resdata interface{}) error {
+	resp, err := c.conn.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resdata != nil {
+		return json.NewDecoder(resp.Body).Decode(resdata)
+	}
+	return nil
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func TestUpload_SmallFile_DirectUpload(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit atomic.Int32
+	fileID := "test-uuid-123"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/info/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "small.txt"})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"uuid": fileID, "parts": []string{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	data := bytes.NewReader(make([]byte, 1*1024*1024)) // 1MB
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data: data,
+		Name: "small.txt",
+		Size: 1 * 1024 * 1024,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "small.txt", info.FileName)
+	assert.Equal(t, int32(1), directHit.Load())
+	assert.Equal(t, int32(0), multipartHit.Load())
+}
+
+func TestUpload_ExactThreshold_DirectUpload(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit atomic.Int32
+	fileID := "test-uuid-exact"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/info/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "exact.bin"})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]interface{}{"uuid": fileID, "parts": []string{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	// File size exactly at DefaultMultipartThreshold → should use direct upload
+	data := bytes.NewReader(make([]byte, DefaultMultipartThreshold))
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data: data,
+		Name: "exact.bin",
+		Size: DefaultMultipartThreshold,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "exact.bin", info.FileName)
+	assert.Equal(t, int32(1), directHit.Load())
+	assert.Equal(t, int32(0), multipartHit.Load())
+}
+
+func TestUpload_LargeFile_MultipartUpload(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit, completeHit atomic.Int32
+	fileID := "test-uuid-456"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":  fileID,
+				"parts": []string{},
+			})
+		case "/multipart/complete/":
+			completeHit.Add(1)
+			json.NewEncoder(w).Encode(FileInfo{FileName: "large.bin"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	data := bytes.NewReader(make([]byte, 20*1024*1024)) // 20MB
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data:        data,
+		Name:        "large.bin",
+		ContentType: "application/octet-stream",
+		Size:        20 * 1024 * 1024,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "large.bin", info.FileName)
+	assert.Equal(t, int32(0), directHit.Load())
+	assert.Equal(t, int32(1), multipartHit.Load())
+}
+
+func TestUpload_CustomThreshold(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit atomic.Int32
+	fileID := "test-uuid-789"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":  fileID,
+				"parts": []string{},
+			})
+		case "/multipart/complete/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "medium.bin"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	data := bytes.NewReader(make([]byte, 5*1024*1024)) // 5MB
+	threshold := int64(3 * 1024 * 1024)                // 3MB threshold
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data:               data,
+		Name:               "medium.bin",
+		ContentType:        "application/octet-stream",
+		Size:               5 * 1024 * 1024,
+		MultipartThreshold: &threshold,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "medium.bin", info.FileName)
+	assert.Equal(t, int32(0), directHit.Load())
+	assert.Equal(t, int32(1), multipartHit.Load())
+}
+
+func TestUpload_ForceDirectUpload(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit atomic.Int32
+	fileID := "test-uuid-force-direct"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/info/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "forced-direct.bin"})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]interface{}{"uuid": fileID, "parts": []string{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	data := bytes.NewReader(make([]byte, 20*1024*1024)) // 20MB, normally multipart
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data:               data,
+		Name:               "forced-direct.bin",
+		Size:               20 * 1024 * 1024,
+		MultipartThreshold: int64Ptr(0), // force direct
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "forced-direct.bin", info.FileName)
+	assert.Equal(t, int32(1), directHit.Load())
+	assert.Equal(t, int32(0), multipartHit.Load())
+}
+
+func TestUpload_ForceMultipartUpload(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit atomic.Int32
+	fileID := "test-uuid-force-multi"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":  fileID,
+				"parts": []string{},
+			})
+		case "/multipart/complete/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "forced-multi.txt"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	data := bytes.NewReader(make([]byte, 1024)) // 1KB, normally direct
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data:               data,
+		Name:               "forced-multi.txt",
+		ContentType:        "text/plain",
+		Size:               1024,
+		MultipartThreshold: int64Ptr(-1), // force multipart
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "forced-multi.txt", info.FileName)
+	assert.Equal(t, int32(0), directHit.Load())
+	assert.Equal(t, int32(1), multipartHit.Load())
+}

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -181,6 +181,7 @@ func TestUpload_LargeFile_MultipartUpload(t *testing.T) {
 	assert.Equal(t, "large.bin", info.FileName)
 	assert.Equal(t, int32(0), directHit.Load())
 	assert.Equal(t, int32(1), multipartHit.Load())
+	assert.Equal(t, int32(1), completeHit.Load())
 }
 
 func TestUpload_CustomThreshold(t *testing.T) {

--- a/webhook/service.go
+++ b/webhook/service.go
@@ -14,7 +14,7 @@ type Service interface {
 	List(context.Context) ([]Info, error)
 	Create(context.Context, Params) (Info, error)
 	Update(context.Context, Params) (Info, error)
-	Delete(ctx context.Context, targetURL string) error
+	Delete(ctx context.Context, id int64) error
 }
 
 type service struct {
@@ -25,7 +25,7 @@ const (
 	listPathFormat   = "/webhooks/"
 	createPathFormat = "/webhooks/"
 	updatePathFormat = "/webhooks/%d/"
-	deletePathFormat = "/webhooks/unsubscribe/"
+	deletePathFormat = "/webhooks/%d/"
 )
 
 // Events

--- a/webhook/service_test.go
+++ b/webhook/service_test.go
@@ -1,0 +1,84 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uploadcare/uploadcare-go/v2/internal/config"
+	"github.com/uploadcare/uploadcare-go/v2/ucare"
+)
+
+type testClient struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func (c *testClient) NewRequest(
+	ctx context.Context,
+	_ config.Endpoint,
+	method, requrl string,
+	data ucare.ReqEncoder,
+) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+requrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	if data != nil {
+		if err = data.EncodeReq(req); err != nil {
+			return nil, err
+		}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/vnd.uploadcare-v0.7+json")
+	return req, nil
+}
+
+func (c *testClient) Do(req *http.Request, resdata interface{}) error {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	if resdata == nil || reflect.ValueOf(resdata).IsNil() {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(resdata)
+}
+
+func newTestService(handler http.Handler) (Service, *httptest.Server) {
+	srv := httptest.NewServer(handler)
+	client := &testClient{httpClient: srv.Client(), baseURL: srv.URL}
+	return NewService(client), srv
+}
+
+func TestWebhookDelete_ByID(t *testing.T) {
+	t.Parallel()
+
+	svc, srv := newTestService(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/webhooks/123/", r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Empty(t, body)
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	err := svc.Delete(context.Background(), 123)
+	assert.NoError(t, err)
+}

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -58,29 +58,19 @@ func (s service) Update(
 	return
 }
 
-// Unsubscribe and delete webhoo
+// Delete removes a webhook by ID.
 func (s service) Delete(
 	ctx context.Context,
-	targetURL string,
+	id int64,
 ) (err error) {
-	var params = deleteParams{targetURL}
-
 	err = s.svc.ResourceOp(
 		ctx,
 		http.MethodDelete,
-		deletePathFormat,
-		params,
+		fmt.Sprintf(deletePathFormat, id),
+		nil,
 		nil,
 	)
 	return
-}
-
-type deleteParams struct {
-	TargetURL string `json:"target_url"`
-}
-
-func (p deleteParams) EncodeReq(req *http.Request) error {
-	return codec.EncodeReqBody(p, req)
 }
 
 // Info holds webhook related information


### PR DESCRIPTION

- add Upload API metadata support and propagate it through unified upload helpers
- add file include params, conversion save_in_group support, and conversion path builder helpers
- change webhook delete to operate on webhook IDs and update docs/changelog/examples
- add unit coverage for codec encoding, file info/list params, conversion helpers, upload metadata, and webhook deletion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added metadata support for file uploads
  * Optional include parameters now available for file operations
  * Conversion path utilities added for document and video processing
  * SaveInGroup parameter added for conversion operations

* **API Changes**
  * file.Info() method signature updated to accept optional parameters
  * webhook.Delete() method updated to use webhook ID instead of URL

<!-- end of auto-generated comment: release notes by coderabbit.ai -->