### PR TITLE
Phase 3: SDK enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,7 @@ IMPROVEMENTS:
 * Add `UserAgent` field to `ucare.Config` for custom agent identification
 * Replace `http.NewRequest` + `WithContext` with `http.NewRequestWithContext`
 * Throttle retry loops now respect context cancellation
-* REST throttling retries now honor `Retry-After` with configurable fail-fast limits and fallback exponential backoff
-* Upload throttling retries now use configurable exponential backoff capping
+* Throttle retries use server `Retry-After` when present, falling back to exponential backoff (capped at 30s); `MaxWaitSeconds` caps the effective wait from either source
 * Error values now expose HTTP status details for caller inspection
 * Replace `ioutil` usage with `io` equivalents
 * Replace `go-env` dependency with `os.Getenv`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ BREAKING CHANGES:
 * Remove `file.OrderBySizeAsc` and `file.OrderBySizeDesc` constants (not supported in v0.7)
 * Remove `APIv05` and `APIv06` constants
 * Minimum Go version is now 1.25
+* Throttled requests no longer retry by default — automatic retries are now opt-in via `ucare.Config.Retry`
 
 FEATURES:
 
@@ -19,12 +20,18 @@ FEATURES:
 * Add `metadata` package with file metadata CRUD operations
 * Add `group.Delete()` for deleting group metadata without deleting files
 * Add webhook event constants for `file.stored`, `file.deleted`, `file.info_updated`, and deprecated `file.infected`
+* Add `ucare.Config.Retry` and `RetryConfig` for configurable throttling retries
+* Add `upload.Service.Upload()` for automatic direct-vs-multipart upload selection
+* Export structured API error types: `APIError`, `AuthError`, `ThrottleError`, `ValidationError`, and `ForbiddenError`
 
 IMPROVEMENTS:
 
 * Add `UserAgent` field to `ucare.Config` for custom agent identification
 * Replace `http.NewRequest` + `WithContext` with `http.NewRequestWithContext`
 * Throttle retry loops now respect context cancellation
+* REST throttling retries now honor `Retry-After` with configurable fail-fast limits and fallback exponential backoff
+* Upload throttling retries now use configurable exponential backoff capping
+* Error values now expose HTTP status details for caller inspection
 * Replace `ioutil` usage with `io` equivalents
 * Replace `go-env` dependency with `os.Getenv`
 * Update `stretchr/testify` to v1.10.0

--- a/internal/codec/codec_test.go
+++ b/internal/codec/codec_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uploadcare/uploadcare-go/v2/file"
 	"github.com/uploadcare/uploadcare-go/v2/internal/codec"
 	"github.com/uploadcare/uploadcare-go/v2/internal/config"
@@ -46,7 +47,8 @@ func TestEncodeReqQuery(t *testing.T) {
 	}, {
 		test:          "empty list",
 		params:        &file.ListParams{},
-		expectedQuery: url.Values{}}, {
+		expectedQuery: url.Values{},
+	}, {
 		test: "part of the params are filled",
 		params: &file.ListParams{
 			Stored:  ucare.Bool(false),
@@ -71,7 +73,6 @@ func TestEncodeReqQuery(t *testing.T) {
 	}}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.test, func(t *testing.T) {
 			t.Parallel()
 
@@ -83,7 +84,7 @@ func TestEncodeReqQuery(t *testing.T) {
 				t.Error("should have no qparams")
 			}
 			for k, v := range c.expectedQuery {
-				assert.Equal(t, q[k], v)
+				assert.Equal(t, v, q[k])
 			}
 		})
 	}
@@ -98,13 +99,12 @@ func TestEncodeReqBody(t *testing.T) {
 		params           interface{}
 		expectedBodyData string
 	}{{
-		test: "slice data",
-
+		test:             "slice data",
 		params:           []string{"test1", "test2"},
 		expectedBodyData: "[\"test1\",\"test2\"]",
 	}}
+
 	for _, c := range cases {
-		c := c
 		t.Run(c.test, func(t *testing.T) {
 			t.Parallel()
 
@@ -112,7 +112,7 @@ func TestEncodeReqBody(t *testing.T) {
 			_ = codec.EncodeReqBody(c.params, req)
 
 			data, err := io.ReadAll(req.Body)
-			assert.Equal(t, nil, err)
+			require.NoError(t, err)
 			assert.Equal(t, c.expectedBodyData, string(data))
 		})
 	}
@@ -124,9 +124,7 @@ func TestEncodeReqFormData(t *testing.T) {
 	cases := []struct {
 		test string
 
-		data interface{}
-		// not validating the form data request
-		// just checking if stuff is there
+		data    interface{}
 		testReq func(written string) error
 		err     bool
 	}{{
@@ -142,23 +140,20 @@ func TestEncodeReqFormData(t *testing.T) {
 			}
 			return nil
 		},
-		err: false,
 	}, {
 		test: "nil data",
 		data: &upload.FileParams{
 			Data: nil,
 			Name: "test_file_name",
 		},
-		testReq: nil,
-		err:     true,
+		err: true,
 	}, {
 		test: "empty file name",
 		data: &upload.FileParams{
 			Data: strings.NewReader("test"),
 			Name: "",
 		},
-		testReq: nil,
-		err:     true,
+		err: true,
 	}, {
 		test: "random data with form value",
 		data: &struct {
@@ -173,7 +168,6 @@ func TestEncodeReqFormData(t *testing.T) {
 			}
 			return nil
 		},
-		err: false,
 	}, {
 		test: "random data holding map",
 		data: &struct {
@@ -188,29 +182,22 @@ func TestEncodeReqFormData(t *testing.T) {
 			}
 			return nil
 		},
-		err: false,
 	}}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.test, func(t *testing.T) {
 			t.Parallel()
 
 			body, _, err := codec.EncodeReqFormData(c.data)
-			if err != nil && !c.err {
-				t.Fatal(err)
-			} else if err == nil && c.err {
-				t.Fatal("error must be returned")
-			}
-
-			if body == nil {
+			if c.err {
+				require.Error(t, err)
 				return
 			}
+			require.NoError(t, err)
 
-			data, _ := io.ReadAll(body)
-
-			assert.Equal(t, nil, err)
-			assert.Equal(t, nil, c.testReq(string(data)))
+			data, err := io.ReadAll(body)
+			require.NoError(t, err)
+			require.NoError(t, c.testReq(string(data)))
 		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,8 +19,6 @@ const (
 
 	AcceptHeaderFormat = "application/vnd.uploadcare-%s+json"
 
-	MaxThrottleRetries = 3
-
 	UCTimeLayout = "2006-01-02T15:04:05"
 )
 

--- a/internal/uctest/client.go
+++ b/internal/uctest/client.go
@@ -62,3 +62,50 @@ func (c *Client) Do(req *http.Request, resdata interface{}) error {
 	}
 	return json.NewDecoder(resp.Body).Decode(resdata)
 }
+
+type UploadClient struct {
+	HTTP    *http.Client
+	BaseURL string
+}
+
+func NewUploadServerClient(srv *httptest.Server) *UploadClient {
+	return &UploadClient{
+		HTTP:    srv.Client(),
+		BaseURL: srv.URL,
+	}
+}
+
+func (c *UploadClient) NewRequest(
+	ctx context.Context,
+	_ config.Endpoint,
+	method, requrl string,
+	data ucare.ReqEncoder,
+) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+requrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	ctx = context.WithValue(req.Context(), config.CtxAuthFuncKey, ucare.UploadAPIAuthFunc(
+		func() (string, *string, *int64) { return "testpubkey", nil, nil },
+	))
+	req = req.WithContext(ctx)
+	if data != nil {
+		if err := data.EncodeReq(req); err != nil {
+			return nil, err
+		}
+	}
+	return req, nil
+}
+
+func (c *UploadClient) Do(req *http.Request, resdata interface{}) error {
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resdata == nil || reflect.ValueOf(resdata).IsNil() {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(resdata)
+}

--- a/ucare/auth_test.go
+++ b/ucare/auth_test.go
@@ -5,52 +5,48 @@ import (
 	"testing"
 	"time"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSimpleAuthRESTAPIParam(t *testing.T) {
+func TestAuth(t *testing.T) {
 	t.Parallel()
 
-	creds := APICreds{
-		SecretKey: "testsk",
-		PublicKey: "testpk",
-	}
+	t.Run("simple_rest_param", func(t *testing.T) {
+		t.Parallel()
 
-	expectedParam := "Uploadcare.Simple testpk:testsk"
-	authParam := simpleRESTAPIAuthParam(creds)
+		creds := APICreds{SecretKey: "testsk", PublicKey: "testpk"}
+		assert.Equal(t, "Uploadcare.Simple testpk:testsk", simpleRESTAPIAuthParam(creds))
+	})
 
-	assert.Equal(t, expectedParam, authParam)
-}
+	t.Run("sign_based_rest_param", func(t *testing.T) {
+		creds := APICreds{SecretKey: "demoprivatekey", PublicKey: "testpk"}
+		req, _ := http.NewRequest(
+			http.MethodGet,
+			"/files/?limit=1&stored=true",
+			nil,
+		)
 
-func TestSignBasedRESTAPIAuthParam(t *testing.T) {
-	creds := APICreds{
-		SecretKey: "demoprivatekey",
-		PublicKey: "testpk",
-	}
-	req, _ := http.NewRequest(
-		http.MethodGet,
-		"/files/?limit=1&stored=true",
-		nil,
-	)
+		// taken from https://uploadcare.com/docs/api_reference/rest/requests_auth/
+		now := time.
+			Unix(1541423681, 0).
+			In(dateHeaderLocation).
+			Format(dateHeaderFormat)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Date", now)
 
-	// taken from https://uploadcare.com/docs/api_reference/rest/requests_auth/
-	now := time.
-		Unix(1541423681, 0).
-		In(dateHeaderLocation).
-		Format(dateHeaderFormat)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Date", now)
+		expected := "Uploadcare testpk:3cbc4d2cf91f80c1ba162b926f8a975e8bec7995"
+		assert.Equal(t, expected, signBasedRESTAPIAuthParam(creds, req))
+	})
 
-	expected := "Uploadcare testpk:3cbc4d2cf91f80c1ba162b926f8a975e8bec7995"
-	authParam := signBasedRESTAPIAuthParam(creds, req)
+	t.Run("sign_based_upload_param", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t, expected, authParam)
-}
+		secret := "project_secret_key"
+		now := int64(1454903856)
+		expected := "d39a461d41f607338abffee5f31da4d4e46535651c87346e76906bf75c064d47"
 
-func TestSignBasedUploadAPIAuthParam(t *testing.T) {
-	secret := "project_secret_key"
-	now := int64(1454903856)
-	expected := "d39a461d41f607338abffee5f31da4d4e46535651c87346e76906bf75c064d47"
-
-	assert.Equal(t, expected, signBasedUploadAPIAuthParam(secret, now))
+		got := signBasedUploadAPIAuthParam(secret, now)
+		require.Equal(t, expected, got)
+	})
 }

--- a/ucare/client.go
+++ b/ucare/client.go
@@ -40,6 +40,9 @@ type Config struct {
 	// UserAgent is appended to the default User-Agent string.
 	// Use this to identify your application (e.g. "my-app/1.0.0").
 	UserAgent string
+	// Retry controls automatic retry of throttled (HTTP 429) requests.
+	// When nil (the default), throttled requests fail immediately.
+	Retry *RetryConfig
 }
 
 // ReqEncoder exists to encode data into the prepared request.

--- a/ucare/client.go
+++ b/ucare/client.go
@@ -42,7 +42,7 @@ type Config struct {
 	UserAgent string
 	// Retry controls automatic retry of throttled (HTTP 429) requests.
 	// When nil (the default), throttled requests fail immediately.
-	// See RetryConfig for REST vs. Upload API differences in MaxWaitSeconds.
+	// See RetryConfig for details on MaxRetries and MaxWaitSeconds.
 	Retry *RetryConfig
 }
 

--- a/ucare/client.go
+++ b/ucare/client.go
@@ -42,6 +42,7 @@ type Config struct {
 	UserAgent string
 	// Retry controls automatic retry of throttled (HTTP 429) requests.
 	// When nil (the default), throttled requests fail immediately.
+	// See RetryConfig for REST vs. Upload API differences in MaxWaitSeconds.
 	Retry *RetryConfig
 }
 

--- a/ucare/config.go
+++ b/ucare/config.go
@@ -5,7 +5,6 @@ import (
 	"time"
 )
 
-// Public configuration constants
 const (
 	APIv07 = "v0.7"
 

--- a/ucare/error.go
+++ b/ucare/error.go
@@ -32,6 +32,8 @@ func (e AuthError) Error() string {
 	return fmt.Sprintf("uploadcare: authentication failed: %s", e.Detail)
 }
 
+func (e AuthError) Unwrap() error { return e.APIError }
+
 type ThrottleError struct {
 	RetryAfter int
 }
@@ -52,8 +54,12 @@ func (e ValidationError) Error() string {
 	return fmt.Sprintf("uploadcare: validation error: %s", e.Detail)
 }
 
+func (e ValidationError) Unwrap() error { return e.APIError }
+
 type ForbiddenError struct{ APIError }
 
 func (e ForbiddenError) Error() string {
 	return fmt.Sprintf("uploadcare: forbidden: %s", e.Detail)
 }
+
+func (e ForbiddenError) Unwrap() error { return e.APIError }

--- a/ucare/error.go
+++ b/ucare/error.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 )
 
-// Sentinel errors for specific conditions
 var (
 	ErrInvalidAuthCreds = errors.New("incorrect authentication credentials")
 	ErrAuthForbidden    = errors.New("simple authentication over HTTP is " +
@@ -18,9 +17,6 @@ var (
 		"files smaller than 100MB")
 )
 
-// APIError represents a generic API error response.
-// Callers can use errors.As to check for this type as a catch-all
-// for any non-specific API error.
 type APIError struct {
 	StatusCode int    `json:"-"`
 	Detail     string `json:"detail"`
@@ -30,14 +26,12 @@ func (e APIError) Error() string {
 	return fmt.Sprintf("uploadcare: HTTP %d: %s", e.StatusCode, e.Detail)
 }
 
-// AuthError represents an authentication failure (HTTP 401).
 type AuthError struct{ APIError }
 
 func (e AuthError) Error() string {
 	return fmt.Sprintf("uploadcare: authentication failed: %s", e.Detail)
 }
 
-// ThrottleError represents a throttled request (HTTP 429).
 type ThrottleError struct {
 	RetryAfter int
 }
@@ -52,14 +46,12 @@ func (e ThrottleError) Error() string {
 	)
 }
 
-// ValidationError represents a request validation failure (HTTP 400).
 type ValidationError struct{ APIError }
 
 func (e ValidationError) Error() string {
 	return fmt.Sprintf("uploadcare: validation error: %s", e.Detail)
 }
 
-// ForbiddenError represents a forbidden request (HTTP 403).
 type ForbiddenError struct{ APIError }
 
 func (e ForbiddenError) Error() string {

--- a/ucare/error.go
+++ b/ucare/error.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// API response errors
+// Sentinel errors for specific conditions
 var (
 	ErrInvalidAuthCreds = errors.New("incorrect authentication credentials")
 	ErrAuthForbidden    = errors.New("simple authentication over HTTP is " +
@@ -18,43 +18,50 @@ var (
 		"files smaller than 100MB")
 )
 
-type respErr struct {
-	Details string `json:"detail"`
+// APIError represents a generic API error response.
+// Callers can use errors.As to check for this type as a catch-all
+// for any non-specific API error.
+type APIError struct {
+	StatusCode int    `json:"-"`
+	Detail     string `json:"detail"`
 }
 
-// Error implements error interface
-func (e respErr) Error() string {
-	return e.Details
+func (e APIError) Error() string {
+	return fmt.Sprintf("uploadcare: HTTP %d: %s", e.StatusCode, e.Detail)
 }
 
-type authErr struct{ respErr }
+// AuthError represents an authentication failure (HTTP 401).
+type AuthError struct{ APIError }
 
-type throttleErr struct {
+func (e AuthError) Error() string {
+	return fmt.Sprintf("uploadcare: authentication failed: %s", e.Detail)
+}
+
+// ThrottleError represents a throttled request (HTTP 429).
+type ThrottleError struct {
 	RetryAfter int
 }
 
-func (e throttleErr) Error() string {
+func (e ThrottleError) Error() string {
 	if e.RetryAfter == 0 {
-		return "Request was throttled."
+		return "uploadcare: request throttled"
 	}
 	return fmt.Sprintf(
-		"Request was throttled. Expected available in %d second",
+		"uploadcare: request throttled, retry after %d seconds",
 		e.RetryAfter,
 	)
 }
 
-type reqValidationErr struct{ respErr }
+// ValidationError represents a request validation failure (HTTP 400).
+type ValidationError struct{ APIError }
 
-func (e reqValidationErr) Error() string {
-	return fmt.Sprintf("Request parameters validation error: %s", e.Details)
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("uploadcare: validation error: %s", e.Detail)
 }
 
-type reqForbiddenErr struct{ respErr }
+// ForbiddenError represents a forbidden request (HTTP 403).
+type ForbiddenError struct{ APIError }
 
-type unexpectedStatusErr struct {
-	StatusCode int
-}
-
-func (e unexpectedStatusErr) Error() string {
-	return fmt.Sprintf("unexpected HTTP status: %d", e.StatusCode)
+func (e ForbiddenError) Error() string {
+	return fmt.Sprintf("uploadcare: forbidden: %s", e.Detail)
 }

--- a/ucare/error_test.go
+++ b/ucare/error_test.go
@@ -4,91 +4,98 @@ import (
 	"errors"
 	"testing"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestAPIError_Error(t *testing.T) {
+func TestError(t *testing.T) {
 	t.Parallel()
-	err := APIError{StatusCode: 404, Detail: "not found"}
-	assert.Equal(t, "uploadcare: HTTP 404: not found", err.Error())
+
+	t.Run("api_error", func(t *testing.T) {
+		t.Parallel()
+		err := APIError{StatusCode: 404, Detail: "not found"}
+		assert.Equal(t, "uploadcare: HTTP 404: not found", err.Error())
+	})
+
+	t.Run("auth_error", func(t *testing.T) {
+		t.Parallel()
+		err := AuthError{APIError{StatusCode: 401, Detail: "invalid token"}}
+		assert.Equal(t, "uploadcare: authentication failed: invalid token", err.Error())
+	})
+
+	t.Run("throttle_error", func(t *testing.T) {
+		t.Parallel()
+		err := ThrottleError{RetryAfter: 5}
+		assert.Equal(t, "uploadcare: request throttled, retry after 5 seconds", err.Error())
+	})
+
+	t.Run("throttle_error_zero_retry", func(t *testing.T) {
+		t.Parallel()
+		err := ThrottleError{}
+		assert.Equal(t, "uploadcare: request throttled", err.Error())
+	})
+
+	t.Run("validation_error", func(t *testing.T) {
+		t.Parallel()
+		err := ValidationError{APIError{StatusCode: 400, Detail: "bad field"}}
+		assert.Equal(t, "uploadcare: validation error: bad field", err.Error())
+	})
+
+	t.Run("forbidden_error", func(t *testing.T) {
+		t.Parallel()
+		err := ForbiddenError{APIError{StatusCode: 403, Detail: "denied"}}
+		assert.Equal(t, "uploadcare: forbidden: denied", err.Error())
+	})
 }
 
-func TestAuthError_Error(t *testing.T) {
+func TestErrorsAs(t *testing.T) {
 	t.Parallel()
-	err := AuthError{APIError{StatusCode: 401, Detail: "invalid token"}}
-	assert.Equal(t, "uploadcare: authentication failed: invalid token", err.Error())
-}
 
-func TestThrottleError_Error(t *testing.T) {
-	t.Parallel()
-	err := ThrottleError{RetryAfter: 5}
-	assert.Equal(t, "uploadcare: request throttled, retry after 5 seconds", err.Error())
-}
+	t.Run("api_error", func(t *testing.T) {
+		t.Parallel()
+		var target APIError
+		err := error(APIError{StatusCode: 409, Detail: "conflict"})
+		assert.True(t, errors.As(err, &target))
+		assert.Equal(t, 409, target.StatusCode)
+	})
 
-func TestThrottleError_Error_ZeroRetryAfter(t *testing.T) {
-	t.Parallel()
-	err := ThrottleError{}
-	assert.Equal(t, "uploadcare: request throttled", err.Error())
-}
+	t.Run("auth_error", func(t *testing.T) {
+		t.Parallel()
+		var target AuthError
+		err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
+		assert.True(t, errors.As(err, &target))
+		assert.Equal(t, 401, target.StatusCode)
+	})
 
-func TestValidationError_Error(t *testing.T) {
-	t.Parallel()
-	err := ValidationError{APIError{StatusCode: 400, Detail: "bad field"}}
-	assert.Equal(t, "uploadcare: validation error: bad field", err.Error())
-}
+	t.Run("throttle_error", func(t *testing.T) {
+		t.Parallel()
+		var target ThrottleError
+		err := error(ThrottleError{RetryAfter: 10})
+		assert.True(t, errors.As(err, &target))
+		assert.Equal(t, 10, target.RetryAfter)
+	})
 
-func TestForbiddenError_Error(t *testing.T) {
-	t.Parallel()
-	err := ForbiddenError{APIError{StatusCode: 403, Detail: "denied"}}
-	assert.Equal(t, "uploadcare: forbidden: denied", err.Error())
-}
+	t.Run("auth_does_not_match_api_error", func(t *testing.T) {
+		t.Parallel()
+		var target APIError
+		err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
+		// AuthError embeds APIError as a value, not a pointer.
+		// errors.As does not unwrap embedded value types, so this does NOT match.
+		assert.False(t, errors.As(err, &target))
+	})
 
-func TestErrorsAs_APIError(t *testing.T) {
-	t.Parallel()
-	var target APIError
-	err := error(APIError{StatusCode: 409, Detail: "conflict"})
-	assert.True(t, errors.As(err, &target))
-	assert.Equal(t, 409, target.StatusCode)
-}
+	t.Run("validation_error", func(t *testing.T) {
+		t.Parallel()
+		var target ValidationError
+		err := error(ValidationError{APIError{StatusCode: 400, Detail: "bad input"}})
+		assert.True(t, errors.As(err, &target))
+		assert.Equal(t, 400, target.StatusCode)
+	})
 
-func TestErrorsAs_AuthError(t *testing.T) {
-	t.Parallel()
-	var target AuthError
-	err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
-	assert.True(t, errors.As(err, &target))
-	assert.Equal(t, 401, target.StatusCode)
-}
-
-func TestErrorsAs_ThrottleError(t *testing.T) {
-	t.Parallel()
-	var target ThrottleError
-	err := error(ThrottleError{RetryAfter: 10})
-	assert.True(t, errors.As(err, &target))
-	assert.Equal(t, 10, target.RetryAfter)
-}
-
-func TestErrorsAs_AuthError_DoesNotMatchAPIError(t *testing.T) {
-	t.Parallel()
-	var target APIError
-	err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
-	// AuthError embeds APIError as a value, not a pointer.
-	// errors.As does not unwrap embedded value types, so this does NOT match.
-	// Callers should check specific types first, then APIError as fallback.
-	assert.False(t, errors.As(err, &target))
-}
-
-func TestErrorsAs_ValidationError(t *testing.T) {
-	t.Parallel()
-	var target ValidationError
-	err := error(ValidationError{APIError{StatusCode: 400, Detail: "bad input"}})
-	assert.True(t, errors.As(err, &target))
-	assert.Equal(t, 400, target.StatusCode)
-}
-
-func TestErrorsAs_ForbiddenError(t *testing.T) {
-	t.Parallel()
-	var target ForbiddenError
-	err := error(ForbiddenError{APIError{StatusCode: 403, Detail: "no"}})
-	assert.True(t, errors.As(err, &target))
-	assert.Equal(t, 403, target.StatusCode)
+	t.Run("forbidden_error", func(t *testing.T) {
+		t.Parallel()
+		var target ForbiddenError
+		err := error(ForbiddenError{APIError{StatusCode: 403, Detail: "no"}})
+		assert.True(t, errors.As(err, &target))
+		assert.Equal(t, 403, target.StatusCode)
+	})
 }

--- a/ucare/error_test.go
+++ b/ucare/error_test.go
@@ -11,110 +11,76 @@ import (
 func TestError(t *testing.T) {
 	t.Parallel()
 
-	t.Run("api_error", func(t *testing.T) {
-		t.Parallel()
-		err := APIError{StatusCode: 404, Detail: "not found"}
-		assert.Equal(t, "uploadcare: HTTP 404: not found", err.Error())
-	})
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"api_error", APIError{StatusCode: 404, Detail: "not found"}, "uploadcare: HTTP 404: not found"},
+		{"auth_error", AuthError{APIError{StatusCode: 401, Detail: "invalid token"}}, "uploadcare: authentication failed: invalid token"},
+		{"throttle_error", ThrottleError{RetryAfter: 5}, "uploadcare: request throttled, retry after 5 seconds"},
+		{"throttle_error_zero", ThrottleError{}, "uploadcare: request throttled"},
+		{"validation_error", ValidationError{APIError{StatusCode: 400, Detail: "bad field"}}, "uploadcare: validation error: bad field"},
+		{"forbidden_error", ForbiddenError{APIError{StatusCode: 403, Detail: "denied"}}, "uploadcare: forbidden: denied"},
+	}
 
-	t.Run("auth_error", func(t *testing.T) {
-		t.Parallel()
-		err := AuthError{APIError{StatusCode: 401, Detail: "invalid token"}}
-		assert.Equal(t, "uploadcare: authentication failed: invalid token", err.Error())
-	})
-
-	t.Run("throttle_error", func(t *testing.T) {
-		t.Parallel()
-		err := ThrottleError{RetryAfter: 5}
-		assert.Equal(t, "uploadcare: request throttled, retry after 5 seconds", err.Error())
-	})
-
-	t.Run("throttle_error_zero_retry", func(t *testing.T) {
-		t.Parallel()
-		err := ThrottleError{}
-		assert.Equal(t, "uploadcare: request throttled", err.Error())
-	})
-
-	t.Run("validation_error", func(t *testing.T) {
-		t.Parallel()
-		err := ValidationError{APIError{StatusCode: 400, Detail: "bad field"}}
-		assert.Equal(t, "uploadcare: validation error: bad field", err.Error())
-	})
-
-	t.Run("forbidden_error", func(t *testing.T) {
-		t.Parallel()
-		err := ForbiddenError{APIError{StatusCode: 403, Detail: "denied"}}
-		assert.Equal(t, "uploadcare: forbidden: denied", err.Error())
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.err.Error())
+		})
+	}
 }
 
 func TestErrorsAs(t *testing.T) {
 	t.Parallel()
 
-	t.Run("api_error", func(t *testing.T) {
+	t.Run("errors_as_own_type", func(t *testing.T) {
 		t.Parallel()
-		var target APIError
-		err := error(APIError{StatusCode: 409, Detail: "conflict"})
-		require.True(t, errors.As(err, &target))
-		assert.Equal(t, 409, target.StatusCode)
+
+		tests := []struct {
+			name   string
+			err    error
+			target any
+			check  func(t *testing.T)
+		}{
+			{"api_error", APIError{StatusCode: 409, Detail: "conflict"}, new(APIError), nil},
+			{"auth_error", AuthError{APIError{StatusCode: 401, Detail: "bad creds"}}, new(AuthError), nil},
+			{"throttle_error", ThrottleError{RetryAfter: 10}, new(ThrottleError), nil},
+			{"validation_error", ValidationError{APIError{StatusCode: 400, Detail: "bad input"}}, new(ValidationError), nil},
+			{"forbidden_error", ForbiddenError{APIError{StatusCode: 403, Detail: "no"}}, new(ForbiddenError), nil},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				require.True(t, errors.As(tt.err, tt.target))
+			})
+		}
 	})
 
-	t.Run("auth_error", func(t *testing.T) {
+	t.Run("unwraps_to_api_error", func(t *testing.T) {
 		t.Parallel()
-		var target AuthError
-		err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
-		require.True(t, errors.As(err, &target))
-		assert.Equal(t, 401, target.StatusCode)
-	})
 
-	t.Run("throttle_error", func(t *testing.T) {
-		t.Parallel()
-		var target ThrottleError
-		err := error(ThrottleError{RetryAfter: 10})
-		require.True(t, errors.As(err, &target))
-		assert.Equal(t, 10, target.RetryAfter)
-	})
+		tests := []struct {
+			name       string
+			err        error
+			wantStatus int
+			wantDetail string
+		}{
+			{"auth", AuthError{APIError{StatusCode: 401, Detail: "bad creds"}}, 401, "bad creds"},
+			{"validation", ValidationError{APIError{StatusCode: 400, Detail: "bad input"}}, 400, "bad input"},
+			{"forbidden", ForbiddenError{APIError{StatusCode: 403, Detail: "no"}}, 403, "no"},
+		}
 
-	t.Run("auth_unwraps_to_api_error", func(t *testing.T) {
-		t.Parallel()
-		var target APIError
-		err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
-		require.True(t, errors.As(err, &target))
-		assert.Equal(t, 401, target.StatusCode)
-		assert.Equal(t, "bad creds", target.Detail)
-	})
-
-	t.Run("validation_unwraps_to_api_error", func(t *testing.T) {
-		t.Parallel()
-		var target APIError
-		err := error(ValidationError{APIError{StatusCode: 400, Detail: "bad input"}})
-		require.True(t, errors.As(err, &target))
-		assert.Equal(t, 400, target.StatusCode)
-		assert.Equal(t, "bad input", target.Detail)
-	})
-
-	t.Run("forbidden_unwraps_to_api_error", func(t *testing.T) {
-		t.Parallel()
-		var target APIError
-		err := error(ForbiddenError{APIError{StatusCode: 403, Detail: "no"}})
-		require.True(t, errors.As(err, &target))
-		assert.Equal(t, 403, target.StatusCode)
-		assert.Equal(t, "no", target.Detail)
-	})
-
-	t.Run("validation_error", func(t *testing.T) {
-		t.Parallel()
-		var target ValidationError
-		err := error(ValidationError{APIError{StatusCode: 400, Detail: "bad input"}})
-		require.True(t, errors.As(err, &target))
-		assert.Equal(t, 400, target.StatusCode)
-	})
-
-	t.Run("forbidden_error", func(t *testing.T) {
-		t.Parallel()
-		var target ForbiddenError
-		err := error(ForbiddenError{APIError{StatusCode: 403, Detail: "no"}})
-		require.True(t, errors.As(err, &target))
-		assert.Equal(t, 403, target.StatusCode)
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				var target APIError
+				require.True(t, errors.As(tt.err, &target))
+				assert.Equal(t, tt.wantStatus, target.StatusCode)
+				assert.Equal(t, tt.wantDetail, target.Detail)
+			})
+		}
 	})
 }

--- a/ucare/error_test.go
+++ b/ucare/error_test.go
@@ -75,13 +75,31 @@ func TestErrorsAs(t *testing.T) {
 		assert.Equal(t, 10, target.RetryAfter)
 	})
 
-	t.Run("auth_does_not_match_api_error", func(t *testing.T) {
+	t.Run("auth_unwraps_to_api_error", func(t *testing.T) {
 		t.Parallel()
 		var target APIError
 		err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
-		// AuthError embeds APIError as a value, not a pointer.
-		// errors.As does not unwrap embedded value types, so this does NOT match.
-		assert.False(t, errors.As(err, &target))
+		require.True(t, errors.As(err, &target))
+		assert.Equal(t, 401, target.StatusCode)
+		assert.Equal(t, "bad creds", target.Detail)
+	})
+
+	t.Run("validation_unwraps_to_api_error", func(t *testing.T) {
+		t.Parallel()
+		var target APIError
+		err := error(ValidationError{APIError{StatusCode: 400, Detail: "bad input"}})
+		require.True(t, errors.As(err, &target))
+		assert.Equal(t, 400, target.StatusCode)
+		assert.Equal(t, "bad input", target.Detail)
+	})
+
+	t.Run("forbidden_unwraps_to_api_error", func(t *testing.T) {
+		t.Parallel()
+		var target APIError
+		err := error(ForbiddenError{APIError{StatusCode: 403, Detail: "no"}})
+		require.True(t, errors.As(err, &target))
+		assert.Equal(t, 403, target.StatusCode)
+		assert.Equal(t, "no", target.Detail)
 	})
 
 	t.Run("validation_error", func(t *testing.T) {

--- a/ucare/error_test.go
+++ b/ucare/error_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestError(t *testing.T) {
@@ -54,7 +55,7 @@ func TestErrorsAs(t *testing.T) {
 		t.Parallel()
 		var target APIError
 		err := error(APIError{StatusCode: 409, Detail: "conflict"})
-		assert.True(t, errors.As(err, &target))
+		require.True(t, errors.As(err, &target))
 		assert.Equal(t, 409, target.StatusCode)
 	})
 
@@ -62,7 +63,7 @@ func TestErrorsAs(t *testing.T) {
 		t.Parallel()
 		var target AuthError
 		err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
-		assert.True(t, errors.As(err, &target))
+		require.True(t, errors.As(err, &target))
 		assert.Equal(t, 401, target.StatusCode)
 	})
 
@@ -70,7 +71,7 @@ func TestErrorsAs(t *testing.T) {
 		t.Parallel()
 		var target ThrottleError
 		err := error(ThrottleError{RetryAfter: 10})
-		assert.True(t, errors.As(err, &target))
+		require.True(t, errors.As(err, &target))
 		assert.Equal(t, 10, target.RetryAfter)
 	})
 
@@ -87,7 +88,7 @@ func TestErrorsAs(t *testing.T) {
 		t.Parallel()
 		var target ValidationError
 		err := error(ValidationError{APIError{StatusCode: 400, Detail: "bad input"}})
-		assert.True(t, errors.As(err, &target))
+		require.True(t, errors.As(err, &target))
 		assert.Equal(t, 400, target.StatusCode)
 	})
 
@@ -95,7 +96,7 @@ func TestErrorsAs(t *testing.T) {
 		t.Parallel()
 		var target ForbiddenError
 		err := error(ForbiddenError{APIError{StatusCode: 403, Detail: "no"}})
-		assert.True(t, errors.As(err, &target))
+		require.True(t, errors.As(err, &target))
 		assert.Equal(t, 403, target.StatusCode)
 	})
 }

--- a/ucare/error_test.go
+++ b/ucare/error_test.go
@@ -1,0 +1,94 @@
+package ucare
+
+import (
+	"errors"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestAPIError_Error(t *testing.T) {
+	t.Parallel()
+	err := APIError{StatusCode: 404, Detail: "not found"}
+	assert.Equal(t, "uploadcare: HTTP 404: not found", err.Error())
+}
+
+func TestAuthError_Error(t *testing.T) {
+	t.Parallel()
+	err := AuthError{APIError{StatusCode: 401, Detail: "invalid token"}}
+	assert.Equal(t, "uploadcare: authentication failed: invalid token", err.Error())
+}
+
+func TestThrottleError_Error(t *testing.T) {
+	t.Parallel()
+	err := ThrottleError{RetryAfter: 5}
+	assert.Equal(t, "uploadcare: request throttled, retry after 5 seconds", err.Error())
+}
+
+func TestThrottleError_Error_ZeroRetryAfter(t *testing.T) {
+	t.Parallel()
+	err := ThrottleError{}
+	assert.Equal(t, "uploadcare: request throttled", err.Error())
+}
+
+func TestValidationError_Error(t *testing.T) {
+	t.Parallel()
+	err := ValidationError{APIError{StatusCode: 400, Detail: "bad field"}}
+	assert.Equal(t, "uploadcare: validation error: bad field", err.Error())
+}
+
+func TestForbiddenError_Error(t *testing.T) {
+	t.Parallel()
+	err := ForbiddenError{APIError{StatusCode: 403, Detail: "denied"}}
+	assert.Equal(t, "uploadcare: forbidden: denied", err.Error())
+}
+
+func TestErrorsAs_APIError(t *testing.T) {
+	t.Parallel()
+	var target APIError
+	err := error(APIError{StatusCode: 409, Detail: "conflict"})
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, 409, target.StatusCode)
+}
+
+func TestErrorsAs_AuthError(t *testing.T) {
+	t.Parallel()
+	var target AuthError
+	err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, 401, target.StatusCode)
+}
+
+func TestErrorsAs_ThrottleError(t *testing.T) {
+	t.Parallel()
+	var target ThrottleError
+	err := error(ThrottleError{RetryAfter: 10})
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, 10, target.RetryAfter)
+}
+
+func TestErrorsAs_AuthError_DoesNotMatchAPIError(t *testing.T) {
+	t.Parallel()
+	var target APIError
+	err := error(AuthError{APIError{StatusCode: 401, Detail: "bad creds"}})
+	// AuthError embeds APIError as a value, not a pointer.
+	// errors.As does not unwrap embedded value types, so this does NOT match.
+	// Callers should check specific types first, then APIError as fallback.
+	assert.False(t, errors.As(err, &target))
+}
+
+func TestErrorsAs_ValidationError(t *testing.T) {
+	t.Parallel()
+	var target ValidationError
+	err := error(ValidationError{APIError{StatusCode: 400, Detail: "bad input"}})
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, 400, target.StatusCode)
+}
+
+func TestErrorsAs_ForbiddenError(t *testing.T) {
+	t.Parallel()
+	var target ForbiddenError
+	err := error(ForbiddenError{APIError{StatusCode: 403, Detail: "no"}})
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, 403, target.StatusCode)
+}

--- a/ucare/restapi.go
+++ b/ucare/restapi.go
@@ -171,6 +171,8 @@ func (c *restAPIClient) handleResponse(
 		}
 		wait := retryAfter
 		if wait <= 0 {
+			// Without a usable Retry-After from the server, REST retries fall
+			// back to exponential backoff instead of applying MaxWaitSeconds.
 			wait = expBackoff(tries)
 		}
 		select {

--- a/ucare/restapi.go
+++ b/ucare/restapi.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -154,31 +153,7 @@ func (c *restAPIClient) handleResponse(
 	case 406:
 		return false, ErrInvalidVersion
 	case 429:
-		retryAfter, err := strconv.Atoi(
-			resp.Header.Get("Retry-After"),
-		)
-		if err != nil || retryAfter < 0 {
-			retryAfter = 0
-		}
-		if c.retry == nil || tries > c.retry.MaxRetries {
-			return false, ThrottleError{RetryAfter: retryAfter}
-		}
-		if c.retry.MaxWaitSeconds > 0 &&
-			retryAfter > c.retry.MaxWaitSeconds {
-			return false, ThrottleError{RetryAfter: retryAfter}
-		}
-		wait := retryAfter
-		if wait <= 0 {
-			// Without a usable Retry-After from the server, REST retries fall
-			// back to exponential backoff instead of applying MaxWaitSeconds.
-			wait = expBackoff(tries)
-		}
-		select {
-		case <-req.Context().Done():
-			return false, req.Context().Err()
-		case <-time.After(time.Duration(wait) * time.Second):
-		}
-		return true, nil
+		return handleThrottle(req.Context(), resp, c.retry, tries)
 	default:
 		if resp.StatusCode >= 400 {
 			apiErr := APIError{StatusCode: resp.StatusCode}

--- a/ucare/restapi.go
+++ b/ucare/restapi.go
@@ -22,7 +22,8 @@ type restAPIClient struct {
 	acceptHeader  string
 	setAuthHeader restAPIAuthFunc
 
-	conn *http.Client
+	conn  *http.Client
+	retry *RetryConfig
 }
 
 func newRESTAPIClient(creds APICreds, conf *Config) Client {
@@ -32,7 +33,8 @@ func newRESTAPIClient(creds APICreds, conf *Config) Client {
 
 		setAuthHeader: simpleRESTAPIAuth,
 
-		conn: conf.HTTPClient,
+		conn:  conf.HTTPClient,
+		retry: conf.Retry,
 	}
 
 	if conf.SignBasedAuthentication {
@@ -131,45 +133,59 @@ func (c *restAPIClient) handleResponse(
 
 	switch resp.StatusCode {
 	case 400, 404:
-		var err respErr
-		if e := json.NewDecoder(resp.Body).Decode(&err); e != nil {
+		var apiErr APIError
+		if e := json.NewDecoder(resp.Body).Decode(&apiErr); e != nil {
 			return false, e
 		}
-		return false, err
+		apiErr.StatusCode = resp.StatusCode
+		return false, apiErr
 	case 401:
-		var err authErr
-		if e := json.NewDecoder(resp.Body).Decode(&err); e != nil {
+		var authErr AuthError
+		if e := json.NewDecoder(resp.Body).Decode(&authErr); e != nil {
 			return false, e
 		}
-		return false, err
+		authErr.StatusCode = 401
+		return false, authErr
+	case 403:
+		var forbiddenErr ForbiddenError
+		if e := json.NewDecoder(resp.Body).Decode(&forbiddenErr); e != nil {
+			return false, e
+		}
+		forbiddenErr.StatusCode = 403
+		return false, forbiddenErr
 	case 406:
 		return false, ErrInvalidVersion
 	case 429:
 		retryAfter, err := strconv.Atoi(
 			resp.Header.Get("Retry-After"),
 		)
-		if err != nil {
-			retryAfter = 5
-		} else if retryAfter < 0 {
+		if err != nil || retryAfter < 0 {
 			retryAfter = 0
 		}
-
-		if tries > config.MaxThrottleRetries {
-			return false, throttleErr{retryAfter}
+		if c.retry == nil || tries > c.retry.MaxRetries {
+			return false, ThrottleError{RetryAfter: retryAfter}
 		}
-
+		if c.retry.MaxWaitSeconds > 0 &&
+			retryAfter > c.retry.MaxWaitSeconds {
+			return false, ThrottleError{RetryAfter: retryAfter}
+		}
+		wait := retryAfter
+		if wait <= 0 {
+			wait = expBackoff(tries)
+		}
 		select {
 		case <-req.Context().Done():
 			return false, req.Context().Err()
-		case <-time.After(time.Duration(retryAfter) * time.Second):
+		case <-time.After(time.Duration(wait) * time.Second):
 		}
 		return true, nil
 	default:
 		if resp.StatusCode >= 400 {
-			var apiErr respErr
-			if e := json.NewDecoder(resp.Body).Decode(&apiErr); e != nil || apiErr.Details == "" {
-				return false, unexpectedStatusErr{StatusCode: resp.StatusCode}
+			var apiErr APIError
+			if e := json.NewDecoder(resp.Body).Decode(&apiErr); e != nil || apiErr.Detail == "" {
+				apiErr.Detail = http.StatusText(resp.StatusCode)
 			}
+			apiErr.StatusCode = resp.StatusCode
 			return false, apiErr
 		}
 	}

--- a/ucare/restapi.go
+++ b/ucare/restapi.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/uploadcare/uploadcare-go/v2/internal/config"
@@ -133,25 +134,22 @@ func (c *restAPIClient) handleResponse(
 
 	switch resp.StatusCode {
 	case 400, 404:
-		var apiErr APIError
-		if e := json.NewDecoder(resp.Body).Decode(&apiErr); e != nil {
-			return false, e
+		apiErr := APIError{StatusCode: resp.StatusCode}
+		if body, _ := io.ReadAll(resp.Body); json.Unmarshal(body, &apiErr) != nil {
+			apiErr.Detail = stringOrStatus(body, resp.StatusCode)
 		}
-		apiErr.StatusCode = resp.StatusCode
 		return false, apiErr
 	case 401:
-		var authErr AuthError
-		if e := json.NewDecoder(resp.Body).Decode(&authErr); e != nil {
-			return false, e
+		authErr := AuthError{APIError: APIError{StatusCode: 401}}
+		if body, _ := io.ReadAll(resp.Body); json.Unmarshal(body, &authErr) != nil {
+			authErr.Detail = stringOrStatus(body, 401)
 		}
-		authErr.StatusCode = 401
 		return false, authErr
 	case 403:
-		var forbiddenErr ForbiddenError
-		if e := json.NewDecoder(resp.Body).Decode(&forbiddenErr); e != nil {
-			return false, e
+		forbiddenErr := ForbiddenError{APIError: APIError{StatusCode: 403}}
+		if body, _ := io.ReadAll(resp.Body); json.Unmarshal(body, &forbiddenErr) != nil {
+			forbiddenErr.Detail = stringOrStatus(body, 403)
 		}
-		forbiddenErr.StatusCode = 403
 		return false, forbiddenErr
 	case 406:
 		return false, ErrInvalidVersion
@@ -183,11 +181,10 @@ func (c *restAPIClient) handleResponse(
 		return true, nil
 	default:
 		if resp.StatusCode >= 400 {
-			var apiErr APIError
-			if e := json.NewDecoder(resp.Body).Decode(&apiErr); e != nil || apiErr.Detail == "" {
-				apiErr.Detail = http.StatusText(resp.StatusCode)
+			apiErr := APIError{StatusCode: resp.StatusCode}
+			if body, _ := io.ReadAll(resp.Body); json.Unmarshal(body, &apiErr) != nil || apiErr.Detail == "" {
+				apiErr.Detail = stringOrStatus(body, resp.StatusCode)
 			}
-			apiErr.StatusCode = resp.StatusCode
 			return false, apiErr
 		}
 	}
@@ -201,6 +198,13 @@ func (c *restAPIClient) handleResponse(
 	}
 
 	return false, nil
+}
+
+func stringOrStatus(body []byte, statusCode int) string {
+	if s := strings.TrimSpace(string(body)); s != "" {
+		return s
+	}
+	return http.StatusText(statusCode)
 }
 
 func isNilResponseData(resdata interface{}) bool {

--- a/ucare/restapi_test.go
+++ b/ucare/restapi_test.go
@@ -2,6 +2,7 @@ package ucare
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -11,7 +12,8 @@ import (
 	"testing"
 	"time"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uploadcare/uploadcare-go/v2/internal/config"
 )
 
@@ -47,6 +49,18 @@ type trackedReadCloser struct {
 func (t trackedReadCloser) Close() error {
 	*t.closed = true
 	return t.ReadCloser.Close()
+}
+
+func respondJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func withServer(t *testing.T, handler http.Handler, fn func(*testing.T, *httptest.Server)) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	fn(t, srv)
 }
 
 func TestRESTAPIClient(t *testing.T) {
@@ -94,7 +108,6 @@ func TestRESTAPIClient(t *testing.T) {
 	}}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.test, func(t *testing.T) {
 			t.Parallel()
 
@@ -105,300 +118,263 @@ func TestRESTAPIClient(t *testing.T) {
 				c.requrl,
 				c.data,
 			)
-			assert.Equal(t, nil, err)
-			assert.Equal(t, nil, c.checkReq(req))
+			require.NoError(t, err)
+			require.NoError(t, c.checkReq(req))
 		})
 	}
 }
 
-func TestDo_UnhandledStatusWithDetail(t *testing.T) {
+func TestDo(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusConflict)
-		_, _ = w.Write([]byte(`{"detail":"Addon is already running for this file."}`))
-	}))
-	defer srv.Close()
+	t.Run("unhandled_status_with_detail", func(t *testing.T) {
+		t.Parallel()
 
-	client := &restAPIClient{conn: srv.Client()}
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/addons/uc_clamav_virus_scan/execute/", nil)
-	assert.NoError(t, err)
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"detail":"Addon is already running for this file."}`))
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &restAPIClient{conn: srv.Client()}
+			req, err := http.NewRequest(http.MethodPost, srv.URL+"/addons/uc_clamav_virus_scan/execute/", nil)
+			require.NoError(t, err)
 
-	var result struct {
-		RequestID string `json:"request_id"`
-	}
-	err = client.Do(req, &result)
+			var result struct {
+				RequestID string `json:"request_id"`
+			}
+			err = client.Do(req, &result)
 
-	assert.Error(t, err)
-	var apiErr APIError
-	assert.True(t, errors.As(err, &apiErr))
-	assert.Equal(t, http.StatusConflict, apiErr.StatusCode)
-	assert.Equal(t, "Addon is already running for this file.", apiErr.Detail)
-	assert.Equal(t, "", result.RequestID)
-}
+			require.Error(t, err)
+			var apiErr APIError
+			assert.True(t, errors.As(err, &apiErr))
+			assert.Equal(t, http.StatusConflict, apiErr.StatusCode)
+			assert.Equal(t, "Addon is already running for this file.", apiErr.Detail)
+			assert.Equal(t, "", result.RequestID)
+		})
+	})
 
-func TestDo_UnhandledStatusWithoutDetail(t *testing.T) {
-	t.Parallel()
+	t.Run("unhandled_status_without_detail", func(t *testing.T) {
+		t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadGateway)
-		_, _ = w.Write([]byte("Bad Gateway"))
-	}))
-	defer srv.Close()
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("Bad Gateway"))
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &restAPIClient{conn: srv.Client()}
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+			require.NoError(t, err)
 
-	client := &restAPIClient{conn: srv.Client()}
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
-	assert.NoError(t, err)
+			var result map[string]string
+			err = client.Do(req, &result)
 
-	var result map[string]string
-	err = client.Do(req, &result)
+			require.Error(t, err)
+			var apiErr APIError
+			assert.True(t, errors.As(err, &apiErr))
+			assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
+			assert.Equal(t, "Bad Gateway", apiErr.Detail)
+		})
+	})
 
-	assert.Error(t, err)
-	var apiErr APIError
-	assert.True(t, errors.As(err, &apiErr))
-	assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
-	assert.Equal(t, "Bad Gateway", apiErr.Detail)
-}
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
 
-func TestDo_Forbidden(t *testing.T) {
-	t.Parallel()
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"detail":"Account is inactive."}`))
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &restAPIClient{conn: srv.Client()}
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+			require.NoError(t, err)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusForbidden)
-		w.Write([]byte(`{"detail":"Account is inactive."}`))
-	}))
-	defer srv.Close()
+			err = client.Do(req, nil)
 
-	client := &restAPIClient{conn: srv.Client()}
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
-	assert.NoError(t, err)
+			require.Error(t, err)
+			var forbiddenErr ForbiddenError
+			assert.True(t, errors.As(err, &forbiddenErr))
+			assert.Equal(t, 403, forbiddenErr.StatusCode)
+			assert.Equal(t, "Account is inactive.", forbiddenErr.Detail)
+		})
+	})
 
-	err = client.Do(req, nil)
+	t.Run("unhandled_status_nil_resdata", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Error(t, err)
-	var forbiddenErr ForbiddenError
-	assert.True(t, errors.As(err, &forbiddenErr))
-	assert.Equal(t, 403, forbiddenErr.StatusCode)
-	assert.Equal(t, "Account is inactive.", forbiddenErr.Detail)
-}
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"detail":"Conflict"}`))
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &restAPIClient{conn: srv.Client()}
+			req, err := http.NewRequest(http.MethodDelete, srv.URL+"/groups/abc~1/", nil)
+			require.NoError(t, err)
 
-func TestDo_UnhandledStatusNilResdata(t *testing.T) {
-	t.Parallel()
+			err = client.Do(req, nil)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusConflict)
-		_, _ = w.Write([]byte(`{"detail":"Conflict"}`))
-	}))
-	defer srv.Close()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "Conflict")
+		})
+	})
 
-	client := &restAPIClient{conn: srv.Client()}
-	req, err := http.NewRequest(http.MethodDelete, srv.URL+"/groups/abc~1/", nil)
-	assert.NoError(t, err)
+	t.Run("success_nil_resdata_closes_body", func(t *testing.T) {
+		t.Parallel()
 
-	err = client.Do(req, nil)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Conflict")
-}
-
-func TestDo_ThrottleMissingRetryAfter(t *testing.T) {
-	t.Parallel()
-
-	calls := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		if calls == 1 {
-			// 429 with no Retry-After header
-			w.WriteHeader(http.StatusTooManyRequests)
-			return
+		closed := false
+		client := &restAPIClient{
+			conn: &http.Client{
+				Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusNoContent,
+						Header:     make(http.Header),
+						Body: trackedReadCloser{
+							ReadCloser: io.NopCloser(strings.NewReader("")),
+							closed:     &closed,
+						},
+					}, nil
+				}),
+			},
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"file-123"}`))
-	}))
-	t.Cleanup(srv.Close)
+		req, err := http.NewRequest(http.MethodDelete, "https://example.test/groups/abc~1/", nil)
+		require.NoError(t, err)
 
-	client := &restAPIClient{conn: srv.Client()}
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
-	assert.NoError(t, err)
-	req.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(strings.NewReader("")), nil
-	}
+		err = client.Do(req, nil)
 
-	var result struct {
-		ID string `json:"id"`
-	}
-	err = client.Do(req, &result)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "file-123", result.ID)
-	assert.Equal(t, 2, calls)
+		require.NoError(t, err)
+		assert.True(t, closed)
+	})
 }
 
-func TestDo_SuccessNilResdataClosesBody(t *testing.T) {
+func TestDoThrottle(t *testing.T) {
 	t.Parallel()
 
-	closed := false
-	client := &restAPIClient{
-		conn: &http.Client{
-			Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNoContent,
-					Header:     make(http.Header),
-					Body: trackedReadCloser{
-						ReadCloser: io.NopCloser(strings.NewReader("")),
-						closed:     &closed,
-					},
-				}, nil
-			}),
-		},
-	}
-	req, err := http.NewRequest(http.MethodDelete, "https://example.test/groups/abc~1/", nil)
-	assert.NoError(t, err)
+	t.Run("no_retry_by_default", func(t *testing.T) {
+		t.Parallel()
 
-	err = client.Do(req, nil)
+		var count atomic.Int32
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			count.Add(1)
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &restAPIClient{conn: srv.Client()}
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+			require.NoError(t, err)
 
-	assert.NoError(t, err)
-	assert.True(t, closed)
-}
+			err = client.Do(req, nil)
 
-func TestDo_ThrottleNoRetryByDefault(t *testing.T) {
-	t.Parallel()
+			require.Error(t, err)
+			var throttleErr ThrottleError
+			assert.True(t, errors.As(err, &throttleErr))
+			assert.Equal(t, 1, throttleErr.RetryAfter)
+			assert.Equal(t, int32(1), count.Load())
+		})
+	})
 
-	var count atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count.Add(1)
-		w.Header().Set("Retry-After", "1")
-		w.WriteHeader(http.StatusTooManyRequests)
-	}))
-	defer srv.Close()
+	t.Run("retry_success", func(t *testing.T) {
+		t.Parallel()
 
-	client := &restAPIClient{conn: srv.Client()}
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
-	assert.NoError(t, err)
+		var count atomic.Int32
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n := count.Add(1)
+			if n < 3 {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			respondJSON(w, map[string]bool{"ok": true})
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &restAPIClient{
+				conn:  srv.Client(),
+				retry: &RetryConfig{MaxRetries: 3},
+			}
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+			require.NoError(t, err)
 
-	err = client.Do(req, nil)
+			var result map[string]bool
+			err = client.Do(req, &result)
 
-	assert.Error(t, err)
-	var throttleErr ThrottleError
-	assert.True(t, errors.As(err, &throttleErr))
-	assert.Equal(t, 1, throttleErr.RetryAfter)
-	assert.Equal(t, int32(1), count.Load())
-}
+			require.NoError(t, err)
+			assert.True(t, result["ok"])
+			assert.Equal(t, int32(3), count.Load())
+		})
+	})
 
-func TestDo_ThrottleRetrySuccess(t *testing.T) {
-	t.Parallel()
+	t.Run("retries_exhausted", func(t *testing.T) {
+		t.Parallel()
 
-	var count atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := count.Add(1)
-		if n < 3 {
+		var count atomic.Int32
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			count.Add(1)
 			w.Header().Set("Retry-After", "0")
 			w.WriteHeader(http.StatusTooManyRequests)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"ok":true}`))
-	}))
-	defer srv.Close()
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &restAPIClient{
+				conn:  srv.Client(),
+				retry: &RetryConfig{MaxRetries: 2},
+			}
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+			require.NoError(t, err)
 
-	client := &restAPIClient{
-		conn:  srv.Client(),
-		retry: &RetryConfig{MaxRetries: 3},
-	}
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
-	assert.NoError(t, err)
+			err = client.Do(req, nil)
 
-	var result map[string]bool
-	err = client.Do(req, &result)
+			require.Error(t, err)
+			var throttleErr ThrottleError
+			assert.True(t, errors.As(err, &throttleErr))
+			// 1st request + 2 retries = 3 total, then on 3rd retry (tries=3) tries > MaxRetries(2)
+			assert.Equal(t, int32(3), count.Load())
+		})
+	})
 
-	assert.NoError(t, err)
-	assert.True(t, result["ok"])
-	assert.Equal(t, int32(3), count.Load())
-}
+	t.Run("max_wait_exceeded", func(t *testing.T) {
+		t.Parallel()
 
-func TestDo_ThrottleRetriesExhausted(t *testing.T) {
-	t.Parallel()
+		var count atomic.Int32
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			count.Add(1)
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &restAPIClient{
+				conn:  srv.Client(),
+				retry: &RetryConfig{MaxRetries: 3, MaxWaitSeconds: 1},
+			}
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+			require.NoError(t, err)
 
-	var count atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count.Add(1)
-		w.Header().Set("Retry-After", "0")
-		w.WriteHeader(http.StatusTooManyRequests)
-	}))
-	defer srv.Close()
+			start := time.Now()
+			err = client.Do(req, nil)
 
-	client := &restAPIClient{
-		conn:  srv.Client(),
-		retry: &RetryConfig{MaxRetries: 2},
-	}
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
-	assert.NoError(t, err)
+			require.Error(t, err)
+			var throttleErr ThrottleError
+			assert.True(t, errors.As(err, &throttleErr))
+			assert.Equal(t, 60, throttleErr.RetryAfter)
+			assert.Equal(t, int32(1), count.Load())
+			assert.Less(t, time.Since(start).Seconds(), 5.0)
+		})
+	})
 
-	err = client.Do(req, nil)
+	t.Run("context_cancelled", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Error(t, err)
-	var throttleErr ThrottleError
-	assert.True(t, errors.As(err, &throttleErr))
-	// 1st request + 2 retries = 3 total, then on 3rd retry (tries=3) tries > MaxRetries(2)
-	assert.Equal(t, int32(3), count.Load())
-}
+		var count atomic.Int32
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			count.Add(1)
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &restAPIClient{
+				conn:  srv.Client(),
+				retry: &RetryConfig{MaxRetries: 3},
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
 
-func TestDo_ThrottleMaxWaitExceeded(t *testing.T) {
-	t.Parallel()
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/files/", nil)
+			require.NoError(t, err)
 
-	var count atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count.Add(1)
-		w.Header().Set("Retry-After", "60")
-		w.WriteHeader(http.StatusTooManyRequests)
-	}))
-	defer srv.Close()
+			err = client.Do(req, nil)
 
-	client := &restAPIClient{
-		conn:  srv.Client(),
-		retry: &RetryConfig{MaxRetries: 3, MaxWaitSeconds: 1},
-	}
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
-	assert.NoError(t, err)
-
-	start := time.Now()
-	err = client.Do(req, nil)
-
-	assert.Error(t, err)
-	var throttleErr ThrottleError
-	assert.True(t, errors.As(err, &throttleErr))
-	assert.Equal(t, 60, throttleErr.RetryAfter)
-	assert.Equal(t, int32(1), count.Load())
-	// The server requested 60s; the client should fail fast instead of retrying.
-	assert.Less(t, time.Since(start).Seconds(), 5.0)
-}
-
-func TestDo_ThrottleContextCancelled(t *testing.T) {
-	t.Parallel()
-
-	var count atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count.Add(1)
-		w.Header().Set("Retry-After", "60")
-		w.WriteHeader(http.StatusTooManyRequests)
-	}))
-	defer srv.Close()
-
-	client := &restAPIClient{
-		conn:  srv.Client(),
-		retry: &RetryConfig{MaxRetries: 3},
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/files/", nil)
-	assert.NoError(t, err)
-
-	err = client.Do(req, nil)
-
-	assert.Error(t, err)
+			require.Error(t, err)
+		})
+	})
 }

--- a/ucare/restapi_test.go
+++ b/ucare/restapi_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -130,9 +131,10 @@ func TestDo_UnhandledStatusWithDetail(t *testing.T) {
 	err = client.Do(req, &result)
 
 	assert.Error(t, err)
-	var apiErr respErr
+	var apiErr APIError
 	assert.True(t, errors.As(err, &apiErr))
-	assert.Equal(t, "Addon is already running for this file.", apiErr.Details)
+	assert.Equal(t, http.StatusConflict, apiErr.StatusCode)
+	assert.Equal(t, "Addon is already running for this file.", apiErr.Detail)
 	assert.Equal(t, "", result.RequestID)
 }
 
@@ -153,9 +155,33 @@ func TestDo_UnhandledStatusWithoutDetail(t *testing.T) {
 	err = client.Do(req, &result)
 
 	assert.Error(t, err)
-	var statusErr unexpectedStatusErr
-	assert.True(t, errors.As(err, &statusErr))
-	assert.Equal(t, http.StatusBadGateway, statusErr.StatusCode)
+	var apiErr APIError
+	assert.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
+	assert.Equal(t, "Bad Gateway", apiErr.Detail)
+}
+
+func TestDo_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"detail":"Account is inactive."}`))
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{conn: srv.Client()}
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var forbiddenErr ForbiddenError
+	assert.True(t, errors.As(err, &forbiddenErr))
+	assert.Equal(t, 403, forbiddenErr.StatusCode)
+	assert.Equal(t, "Account is inactive.", forbiddenErr.Detail)
 }
 
 func TestDo_UnhandledStatusNilResdata(t *testing.T) {
@@ -236,4 +262,143 @@ func TestDo_SuccessNilResdataClosesBody(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.True(t, closed)
+}
+
+func TestDo_ThrottleNoRetryByDefault(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{conn: srv.Client()}
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var throttleErr ThrottleError
+	assert.True(t, errors.As(err, &throttleErr))
+	assert.Equal(t, 1, throttleErr.RetryAfter)
+	assert.Equal(t, int32(1), count.Load())
+}
+
+func TestDo_ThrottleRetrySuccess(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := count.Add(1)
+		if n < 3 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{
+		conn:  srv.Client(),
+		retry: &RetryConfig{MaxRetries: 3},
+	}
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	var result map[string]bool
+	err = client.Do(req, &result)
+
+	assert.NoError(t, err)
+	assert.True(t, result["ok"])
+	assert.Equal(t, int32(3), count.Load())
+}
+
+func TestDo_ThrottleRetriesExhausted(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{
+		conn:  srv.Client(),
+		retry: &RetryConfig{MaxRetries: 2},
+	}
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var throttleErr ThrottleError
+	assert.True(t, errors.As(err, &throttleErr))
+	// 1st request + 2 retries = 3 total, then on 3rd retry (tries=3) tries > MaxRetries(2)
+	assert.Equal(t, int32(3), count.Load())
+}
+
+func TestDo_ThrottleMaxWaitExceeded(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{
+		conn:  srv.Client(),
+		retry: &RetryConfig{MaxRetries: 3, MaxWaitSeconds: 1},
+	}
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	start := time.Now()
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var throttleErr ThrottleError
+	assert.True(t, errors.As(err, &throttleErr))
+	assert.Equal(t, 60, throttleErr.RetryAfter)
+	assert.Equal(t, int32(1), count.Load())
+	// The server requested 60s; the client should fail fast instead of retrying.
+	assert.Less(t, time.Since(start).Seconds(), 5.0)
+}
+
+func TestDo_ThrottleContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := &restAPIClient{
+		conn:  srv.Client(),
+		retry: &RetryConfig{MaxRetries: 3},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/files/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
 }

--- a/ucare/restapi_test.go
+++ b/ucare/restapi_test.go
@@ -146,7 +146,7 @@ func TestDo(t *testing.T) {
 
 			require.Error(t, err)
 			var apiErr APIError
-			assert.True(t, errors.As(err, &apiErr))
+			require.True(t, errors.As(err, &apiErr))
 			assert.Equal(t, http.StatusConflict, apiErr.StatusCode)
 			assert.Equal(t, "Addon is already running for this file.", apiErr.Detail)
 			assert.Equal(t, "", result.RequestID)
@@ -169,7 +169,7 @@ func TestDo(t *testing.T) {
 
 			require.Error(t, err)
 			var apiErr APIError
-			assert.True(t, errors.As(err, &apiErr))
+			require.True(t, errors.As(err, &apiErr))
 			assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
 			assert.Equal(t, "Bad Gateway", apiErr.Detail)
 		})
@@ -191,7 +191,7 @@ func TestDo(t *testing.T) {
 
 			require.Error(t, err)
 			var forbiddenErr ForbiddenError
-			assert.True(t, errors.As(err, &forbiddenErr))
+			require.True(t, errors.As(err, &forbiddenErr))
 			assert.Equal(t, 403, forbiddenErr.StatusCode)
 			assert.Equal(t, "Account is inactive.", forbiddenErr.Detail)
 		})
@@ -264,7 +264,7 @@ func TestDoThrottle(t *testing.T) {
 
 			require.Error(t, err)
 			var throttleErr ThrottleError
-			assert.True(t, errors.As(err, &throttleErr))
+			require.True(t, errors.As(err, &throttleErr))
 			assert.Equal(t, 1, throttleErr.RetryAfter)
 			assert.Equal(t, int32(1), count.Load())
 		})
@@ -319,7 +319,7 @@ func TestDoThrottle(t *testing.T) {
 
 			require.Error(t, err)
 			var throttleErr ThrottleError
-			assert.True(t, errors.As(err, &throttleErr))
+			require.True(t, errors.As(err, &throttleErr))
 			// 1st request + 2 retries = 3 total, then on 3rd retry (tries=3) tries > MaxRetries(2)
 			assert.Equal(t, int32(3), count.Load())
 		})
@@ -346,7 +346,7 @@ func TestDoThrottle(t *testing.T) {
 
 			require.Error(t, err)
 			var throttleErr ThrottleError
-			assert.True(t, errors.As(err, &throttleErr))
+			require.True(t, errors.As(err, &throttleErr))
 			assert.Equal(t, 60, throttleErr.RetryAfter)
 			assert.Equal(t, int32(1), count.Load())
 			assert.Less(t, time.Since(start).Seconds(), 5.0)

--- a/ucare/retry.go
+++ b/ucare/retry.go
@@ -1,0 +1,20 @@
+package ucare
+
+// RetryConfig controls automatic retry of throttled (HTTP 429) requests.
+// When nil in Config (the default), throttled requests fail immediately.
+type RetryConfig struct {
+	// MaxRetries is the maximum number of retry attempts.
+	// 0 means no retries even if RetryConfig is set.
+	MaxRetries int
+	// MaxWaitSeconds caps retry waits.
+	// For REST requests, a positive Retry-After above this cap fails fast.
+	// For upload requests, locally computed backoff is clamped to this cap.
+	// 0 means no cap.
+	MaxWaitSeconds int
+}
+
+// expBackoff returns exponential backoff wait: 1, 2, 4, 8... capped at 30s.
+func expBackoff(attempt int) int {
+	wait := 1 << (attempt - 1)
+	return min(wait, 30)
+}

--- a/ucare/retry.go
+++ b/ucare/retry.go
@@ -6,9 +6,14 @@ type RetryConfig struct {
 	// MaxRetries is the maximum number of retry attempts.
 	// 0 means no retries even if RetryConfig is set.
 	MaxRetries int
-	// MaxWaitSeconds caps retry waits.
-	// For REST requests, a positive Retry-After above this cap fails fast.
-	// For upload requests, locally computed backoff is clamped to this cap.
+	// MaxWaitSeconds limits retry waits, but the exact behavior depends on
+	// which API returned HTTP 429:
+	//   - REST API: if the server sends a positive Retry-After above this
+	//     value, the request fails fast with ThrottleError instead of retrying.
+	//     Fallback exponential backoff used when Retry-After is absent or
+	//     invalid is not capped by this field.
+	//   - Upload API: locally computed exponential backoff is clamped to this
+	//     value because the upload API does not return Retry-After.
 	// 0 means no cap.
 	MaxWaitSeconds int
 }

--- a/ucare/retry.go
+++ b/ucare/retry.go
@@ -1,8 +1,57 @@
 package ucare
 
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+)
+
 type RetryConfig struct {
 	MaxRetries     int
 	MaxWaitSeconds int
+}
+
+// handleThrottle decides whether to retry a 429 response. It returns
+// (true, nil) after sleeping when a retry should be attempted, or
+// (false, ThrottleError) when retries are exhausted or the wait
+// exceeds the configured cap.
+func handleThrottle(
+	ctx context.Context,
+	resp *http.Response,
+	retry *RetryConfig,
+	tries int,
+) (bool, error) {
+	retryAfter, err := strconv.Atoi(
+		resp.Header.Get("Retry-After"),
+	)
+	if err != nil || retryAfter < 0 {
+		retryAfter = 0
+	}
+
+	if retry == nil || tries > retry.MaxRetries {
+		return false, ThrottleError{RetryAfter: retryAfter}
+	}
+
+	// Only bail out when the server explicitly asks for a wait that
+	// exceeds our cap. Locally computed backoff is already bounded
+	// by expBackoff's hardcoded ceiling and does not need capping.
+	if retry.MaxWaitSeconds > 0 &&
+		retryAfter > retry.MaxWaitSeconds {
+		return false, ThrottleError{RetryAfter: retryAfter}
+	}
+
+	wait := retryAfter
+	if wait <= 0 {
+		wait = expBackoff(tries)
+	}
+
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case <-time.After(time.Duration(wait) * time.Second):
+	}
+	return true, nil
 }
 
 func expBackoff(attempt int) int {

--- a/ucare/retry.go
+++ b/ucare/retry.go
@@ -7,6 +7,13 @@ import (
 	"time"
 )
 
+// RetryConfig controls automatic retry of throttled (HTTP 429) requests.
+//
+// MaxRetries limits how many times a request is retried.
+// MaxWaitSeconds caps the per-retry wait time. When the effective wait
+// (either the server's Retry-After value or the computed exponential
+// backoff) exceeds this cap, the request fails immediately with a
+// ThrottleError instead of sleeping. Set to 0 to disable the cap.
 type RetryConfig struct {
 	MaxRetries     int
 	MaxWaitSeconds int
@@ -33,17 +40,13 @@ func handleThrottle(
 		return false, ThrottleError{RetryAfter: retryAfter}
 	}
 
-	// Only bail out when the server explicitly asks for a wait that
-	// exceeds our cap. Locally computed backoff is already bounded
-	// by expBackoff's hardcoded ceiling and does not need capping.
-	if retry.MaxWaitSeconds > 0 &&
-		retryAfter > retry.MaxWaitSeconds {
-		return false, ThrottleError{RetryAfter: retryAfter}
-	}
-
 	wait := retryAfter
 	if wait <= 0 {
 		wait = expBackoff(tries)
+	}
+
+	if retry.MaxWaitSeconds > 0 && wait > retry.MaxWaitSeconds {
+		return false, ThrottleError{RetryAfter: wait}
 	}
 
 	select {

--- a/ucare/retry.go
+++ b/ucare/retry.go
@@ -1,24 +1,10 @@
 package ucare
 
-// RetryConfig controls automatic retry of throttled (HTTP 429) requests.
-// When nil in Config (the default), throttled requests fail immediately.
 type RetryConfig struct {
-	// MaxRetries is the maximum number of retry attempts.
-	// 0 means no retries even if RetryConfig is set.
-	MaxRetries int
-	// MaxWaitSeconds limits retry waits, but the exact behavior depends on
-	// which API returned HTTP 429:
-	//   - REST API: if the server sends a positive Retry-After above this
-	//     value, the request fails fast with ThrottleError instead of retrying.
-	//     Fallback exponential backoff used when Retry-After is absent or
-	//     invalid is not capped by this field.
-	//   - Upload API: locally computed exponential backoff is clamped to this
-	//     value because the upload API does not return Retry-After.
-	// 0 means no cap.
+	MaxRetries     int
 	MaxWaitSeconds int
 }
 
-// expBackoff returns exponential backoff wait: 1, 2, 4, 8... capped at 30s.
 func expBackoff(attempt int) int {
 	wait := 1 << (attempt - 1)
 	return min(wait, 30)

--- a/ucare/retry_test.go
+++ b/ucare/retry_test.go
@@ -1,0 +1,29 @@
+package ucare
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestExpBackoff(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		attempt int
+		want    int
+	}{
+		{1, 1},
+		{2, 2},
+		{3, 4},
+		{4, 8},
+		{5, 16},
+		{6, 30}, // capped
+		{7, 30},
+		{10, 30},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, expBackoff(c.attempt), "attempt %d", c.attempt)
+	}
+}

--- a/ucare/retry_test.go
+++ b/ucare/retry_test.go
@@ -1,9 +1,10 @@
 package ucare
 
 import (
+	"fmt"
 	"testing"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExpBackoff(t *testing.T) {
@@ -24,6 +25,9 @@ func TestExpBackoff(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		assert.Equal(t, c.want, expBackoff(c.attempt), "attempt %d", c.attempt)
+		t.Run(fmt.Sprintf("attempt_%d", c.attempt), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.want, expBackoff(c.attempt))
+		})
 	}
 }

--- a/ucare/retry_test.go
+++ b/ucare/retry_test.go
@@ -1,11 +1,131 @@
 package ucare
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestHandleThrottle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		retryAfter     string
+		cfg            *RetryConfig
+		tries          int
+		cancelCtx      bool
+		wantOK         bool
+		wantRetryAfter int // checked only when wantOK=false and cancelCtx=false
+	}{
+		{
+			name:           "nil_config",
+			retryAfter:     "5",
+			cfg:            nil,
+			tries:          1,
+			wantRetryAfter: 5,
+		},
+		{
+			name:       "retries_exhausted",
+			retryAfter: "1",
+			cfg:        &RetryConfig{MaxRetries: 2, MaxWaitSeconds: 60},
+			tries:      3,
+		},
+		{
+			name:           "retry_after_exceeds_max_wait",
+			retryAfter:     "10",
+			cfg:            &RetryConfig{MaxRetries: 5, MaxWaitSeconds: 3},
+			tries:          1,
+			wantRetryAfter: 10,
+		},
+		{
+			name:           "no_retry_after_backoff_exceeds_max_wait",
+			retryAfter:     "",
+			cfg:            &RetryConfig{MaxRetries: 10, MaxWaitSeconds: 3},
+			tries:          5, // expBackoff=16 > 3
+			wantRetryAfter: 16,
+		},
+		{
+			name:           "invalid_retry_after_backoff_exceeds_max_wait",
+			retryAfter:     "not-a-number",
+			cfg:            &RetryConfig{MaxRetries: 10, MaxWaitSeconds: 3},
+			tries:          5, // expBackoff=16 > 3
+			wantRetryAfter: 16,
+		},
+		{
+			name:       "no_retry_after_within_max_wait",
+			retryAfter: "",
+			cfg:        &RetryConfig{MaxRetries: 10, MaxWaitSeconds: 60},
+			tries:      1, // expBackoff=1 <= 60
+			wantOK:     true,
+		},
+		{
+			name:       "retry_after_within_max_wait",
+			retryAfter: "1",
+			cfg:        &RetryConfig{MaxRetries: 5, MaxWaitSeconds: 10},
+			tries:      1,
+			wantOK:     true,
+		},
+		{
+			name:      "context_cancelled",
+			retryAfter: "1",
+			cfg:       &RetryConfig{MaxRetries: 5, MaxWaitSeconds: 60},
+			tries:     1,
+			cancelCtx: true,
+		},
+		{
+			name:       "max_wait_zero_unlimited",
+			retryAfter: "",
+			cfg:        &RetryConfig{MaxRetries: 10, MaxWaitSeconds: 0},
+			tries:      1, // expBackoff=1; no cap
+			wantOK:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			if tt.retryAfter != "" {
+				rec.Header().Set("Retry-After", tt.retryAfter)
+			}
+			resp := rec.Result()
+
+			ctx := context.Background()
+			if tt.cancelCtx {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			ok, err := handleThrottle(ctx, resp, tt.cfg, tt.tries)
+			assert.Equal(t, tt.wantOK, ok)
+
+			if tt.wantOK {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			if tt.cancelCtx {
+				assert.ErrorIs(t, err, context.Canceled)
+				return
+			}
+
+			if tt.wantRetryAfter > 0 {
+				var te ThrottleError
+				require.True(t, errors.As(err, &te))
+				assert.Equal(t, tt.wantRetryAfter, te.RetryAfter)
+			}
+		})
+	}
+}
 
 func TestExpBackoff(t *testing.T) {
 	t.Parallel()

--- a/ucare/uploadapi.go
+++ b/ucare/uploadapi.go
@@ -155,7 +155,7 @@ func (c *uploadAPIClient) handleResponse(
 		return false, nil
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&resdata); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(resdata); err != nil {
 		return false, err
 	}
 

--- a/ucare/uploadapi.go
+++ b/ucare/uploadapi.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"time"
 
 	"github.com/uploadcare/uploadcare-go/v2/internal/config"
@@ -15,13 +14,15 @@ import (
 type uploadAPIClient struct {
 	authFunc UploadAPIAuthFunc
 
-	conn *http.Client
+	conn  *http.Client
+	retry *RetryConfig
 }
 
 func newUploadAPIClient(creds APICreds, conf *Config) Client {
 	c := uploadAPIClient{
 		authFunc: simpleUploadAPIAuthFunc(creds),
 		conn:     conf.HTTPClient,
+		retry:    conf.Retry,
 	}
 
 	if conf.SignBasedAuthentication {
@@ -70,67 +71,93 @@ func (c *uploadAPIClient) Do(
 	req *http.Request,
 	resdata interface{},
 ) error {
-	tries := 0
-try:
-	tries++
+	for tries := 1; ; tries++ {
+		if tries > 1 && req.GetBody != nil {
+			var err error
+			req.Body, err = req.GetBody()
+			if err != nil {
+				return err
+			}
+		}
 
-	if tries > 1 && req.GetBody != nil {
-		var err error
-		req.Body, err = req.GetBody()
+		log.Debugf("making %d request: %s %+v", tries, req.Method, req.URL)
+
+		resp, err := c.conn.Do(req)
 		if err != nil {
 			return err
 		}
-	}
 
-	log.Debugf("making %d request: %s %+v", tries, req.Method, req.URL)
+		retry, err := c.handleResponse(resp, resdata, tries)
+		if err != nil || !retry {
+			return err
+		}
+	}
+}
 
-	resp, err := c.conn.Do(req)
-	if err != nil {
-		return err
-	}
-	if req.Body != nil {
-		defer func() { _ = req.Body.Close() }()
-	}
+func (c *uploadAPIClient) handleResponse(
+	resp *http.Response,
+	resdata interface{},
+	tries int,
+) (bool, error) {
+	defer resp.Body.Close()
 
 	log.Debugf("received response: %+v", resp)
 
 	switch resp.StatusCode {
-	case 400, 403:
+	case 400:
 		data, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return err
+			return false, err
 		}
-		_ = resp.Body.Close()
-		switch resp.StatusCode {
-		case 400:
-			return reqValidationErr{respErr{string(data)}}
-		case 403:
-			return reqForbiddenErr{respErr{string(data)}}
+		return false, ValidationError{APIError{StatusCode: 400, Detail: string(data)}}
+	case 403:
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
 		}
+		return false, ForbiddenError{APIError{StatusCode: 403, Detail: string(data)}}
 	case 413:
-		return ErrFileTooLarge
+		return false, ErrFileTooLarge
 	case 429:
-		if tries > config.MaxThrottleRetries {
-			return throttleErr{}
+		if c.retry == nil || tries > c.retry.MaxRetries {
+			return false, ThrottleError{}
 		}
-		// retry after is not returned from the upload API
+		wait := expBackoff(tries)
+		if c.retry.MaxWaitSeconds > 0 && wait > c.retry.MaxWaitSeconds {
+			wait = c.retry.MaxWaitSeconds
+		}
 		select {
-		case <-req.Context().Done():
-			return req.Context().Err()
-		case <-time.After(5 * time.Second):
+		case <-resp.Request.Context().Done():
+			return false, resp.Request.Context().Err()
+		case <-time.After(time.Duration(wait) * time.Second):
 		}
-		goto try
+		return true, nil
 	default:
+		if resp.StatusCode >= 400 {
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return false, err
+			}
+			var apiErr APIError
+			if json.Unmarshal(body, &apiErr) != nil || apiErr.Detail == "" {
+				detail := string(body)
+				if detail == "" {
+					detail = http.StatusText(resp.StatusCode)
+				}
+				apiErr.Detail = detail
+			}
+			apiErr.StatusCode = resp.StatusCode
+			return false, apiErr
+		}
 	}
 
-	if resdata == nil || reflect.ValueOf(resdata).IsNil() {
-		return nil
+	if isNilResponseData(resdata) {
+		return false, nil
 	}
-	err = json.NewDecoder(resp.Body).Decode(&resdata)
-	if err != nil {
-		return err
-	}
-	_ = resp.Body.Close()
 
-	return nil
+	if err := json.NewDecoder(resp.Body).Decode(&resdata); err != nil {
+		return false, err
+	}
+
+	return false, nil
 }

--- a/ucare/uploadapi.go
+++ b/ucare/uploadapi.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/uploadcare/uploadcare-go/v2/internal/config"
 )
@@ -119,19 +118,7 @@ func (c *uploadAPIClient) handleResponse(
 	case 413:
 		return false, ErrFileTooLarge
 	case 429:
-		if c.retry == nil || tries > c.retry.MaxRetries {
-			return false, ThrottleError{}
-		}
-		wait := expBackoff(tries)
-		if c.retry.MaxWaitSeconds > 0 && wait > c.retry.MaxWaitSeconds {
-			wait = c.retry.MaxWaitSeconds
-		}
-		select {
-		case <-resp.Request.Context().Done():
-			return false, resp.Request.Context().Err()
-		case <-time.After(time.Duration(wait) * time.Second):
-		}
-		return true, nil
+		return handleThrottle(resp.Request.Context(), resp, c.retry, tries)
 	default:
 		if resp.StatusCode >= 400 {
 			body, err := io.ReadAll(resp.Body)

--- a/ucare/uploadapi.go
+++ b/ucare/uploadapi.go
@@ -99,7 +99,7 @@ func (c *uploadAPIClient) handleResponse(
 	resdata interface{},
 	tries int,
 ) (bool, error) {
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	log.Debugf("received response: %+v", resp)
 

--- a/ucare/uploadapi_test.go
+++ b/ucare/uploadapi_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -64,4 +66,79 @@ func TestUploadAPIClient(t *testing.T) {
 			assert.Equal(t, nil, c.checkReq(req))
 		})
 	}
+}
+
+func TestUploadDo_ThrottleNoRetryByDefault(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := &uploadAPIClient{conn: srv.Client()}
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var throttleErr ThrottleError
+	assert.True(t, errors.As(err, &throttleErr))
+	assert.Equal(t, int32(1), count.Load())
+}
+
+func TestUploadDo_ThrottleRetrySuccess(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := count.Add(1)
+		if n < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"file":"test-id"}`))
+	}))
+	defer srv.Close()
+
+	client := &uploadAPIClient{
+		conn:  srv.Client(),
+		retry: &RetryConfig{MaxRetries: 3},
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+	assert.NoError(t, err)
+
+	var result map[string]string
+	err = client.Do(req, &result)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "test-id", result["file"])
+	assert.Equal(t, int32(2), count.Load())
+}
+
+func TestUploadDo_UnhandledStatusPlainTextBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		w.Write([]byte("upstream connect error"))
+	}))
+	defer srv.Close()
+
+	client := &uploadAPIClient{conn: srv.Client()}
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+	assert.NoError(t, err)
+
+	err = client.Do(req, nil)
+
+	assert.Error(t, err)
+	var apiErr APIError
+	assert.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
+	assert.Equal(t, "upstream connect error", apiErr.Detail)
 }

--- a/ucare/uploadapi_test.go
+++ b/ucare/uploadapi_test.go
@@ -86,7 +86,7 @@ func TestUploadDo(t *testing.T) {
 
 			require.Error(t, err)
 			var throttleErr ThrottleError
-			assert.True(t, errors.As(err, &throttleErr))
+			require.True(t, errors.As(err, &throttleErr))
 			assert.Equal(t, int32(1), count.Load())
 		})
 	})
@@ -134,7 +134,7 @@ func TestUploadDo(t *testing.T) {
 
 			require.Error(t, err)
 			var invalidUnmarshal *json.InvalidUnmarshalError
-			assert.True(t, errors.As(err, &invalidUnmarshal))
+			require.True(t, errors.As(err, &invalidUnmarshal))
 		})
 	})
 
@@ -153,7 +153,7 @@ func TestUploadDo(t *testing.T) {
 
 			require.Error(t, err)
 			var apiErr APIError
-			assert.True(t, errors.As(err, &apiErr))
+			require.True(t, errors.As(err, &apiErr))
 			assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
 			assert.Equal(t, "upstream connect error", apiErr.Detail)
 		})

--- a/ucare/uploadapi_test.go
+++ b/ucare/uploadapi_test.go
@@ -10,7 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uploadcare/uploadcare-go/v2/internal/config"
 )
 
@@ -29,7 +30,7 @@ func TestUploadAPIClient(t *testing.T) {
 
 		checkReq func(*http.Request) error
 	}{{
-		test:     "simple case ",
+		test:     "form_data",
 		endpoint: config.UploadAPIEndpoint,
 		method:   http.MethodPost,
 		requrl:   "/base/",
@@ -38,21 +39,18 @@ func TestUploadAPIClient(t *testing.T) {
 			query: "qparam1=qparamvalue1&qparam2=qparamvalue2",
 		},
 		checkReq: func(r *http.Request) error {
-			// check only data in this test case
 			data, _ := io.ReadAll(r.Body)
 			if string(data) != "formkey=formvalue" {
 				return errors.New("invalid req body data")
 			}
-			qr := r.URL.RawQuery
-			if qr != "qparam1=qparamvalue1&qparam2=qparamvalue2" {
-				return errors.New("invlid req query")
+			if r.URL.RawQuery != "qparam1=qparamvalue1&qparam2=qparamvalue2" {
+				return errors.New("invalid req query")
 			}
 			return nil
 		},
 	}}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.test, func(t *testing.T) {
 			t.Parallel()
 
@@ -63,105 +61,101 @@ func TestUploadAPIClient(t *testing.T) {
 				c.requrl,
 				c.data,
 			)
-			assert.Equal(t, nil, err)
-			assert.Equal(t, nil, c.checkReq(req))
+			require.NoError(t, err)
+			require.NoError(t, c.checkReq(req))
 		})
 	}
 }
 
-func TestUploadDo_ThrottleNoRetryByDefault(t *testing.T) {
+func TestUploadDo(t *testing.T) {
 	t.Parallel()
 
-	var count atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count.Add(1)
-		w.WriteHeader(http.StatusTooManyRequests)
-	}))
-	defer srv.Close()
+	t.Run("throttle_no_retry_by_default", func(t *testing.T) {
+		t.Parallel()
 
-	client := &uploadAPIClient{conn: srv.Client()}
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
-	assert.NoError(t, err)
-
-	err = client.Do(req, nil)
-
-	assert.Error(t, err)
-	var throttleErr ThrottleError
-	assert.True(t, errors.As(err, &throttleErr))
-	assert.Equal(t, int32(1), count.Load())
-}
-
-func TestUploadDo_ThrottleRetrySuccess(t *testing.T) {
-	t.Parallel()
-
-	var count atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := count.Add(1)
-		if n < 2 {
+		var count atomic.Int32
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			count.Add(1)
 			w.WriteHeader(http.StatusTooManyRequests)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"file":"test-id"}`))
-	}))
-	defer srv.Close()
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &uploadAPIClient{conn: srv.Client()}
+			req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+			require.NoError(t, err)
 
-	client := &uploadAPIClient{
-		conn:  srv.Client(),
-		retry: &RetryConfig{MaxRetries: 3},
-	}
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
-	assert.NoError(t, err)
+			err = client.Do(req, nil)
 
-	var result map[string]string
-	err = client.Do(req, &result)
+			require.Error(t, err)
+			var throttleErr ThrottleError
+			assert.True(t, errors.As(err, &throttleErr))
+			assert.Equal(t, int32(1), count.Load())
+		})
+	})
 
-	assert.NoError(t, err)
-	assert.Equal(t, "test-id", result["file"])
-	assert.Equal(t, int32(2), count.Load())
-}
+	t.Run("throttle_retry_success", func(t *testing.T) {
+		t.Parallel()
 
-func TestUploadDo_SuccessRequiresPointerResdata(t *testing.T) {
-	t.Parallel()
+		var count atomic.Int32
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n := count.Add(1)
+			if n < 2 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			respondJSON(w, map[string]string{"file": "test-id"})
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &uploadAPIClient{
+				conn:  srv.Client(),
+				retry: &RetryConfig{MaxRetries: 3},
+			}
+			req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+			require.NoError(t, err)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"file":"test-id"}`))
-	}))
-	defer srv.Close()
+			var result map[string]string
+			err = client.Do(req, &result)
 
-	client := &uploadAPIClient{conn: srv.Client()}
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
-	assert.NoError(t, err)
+			require.NoError(t, err)
+			assert.Equal(t, "test-id", result["file"])
+			assert.Equal(t, int32(2), count.Load())
+		})
+	})
 
-	result := map[string]string{}
-	err = client.Do(req, result)
+	t.Run("requires_pointer_resdata", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Error(t, err)
-	var invalidUnmarshal *json.InvalidUnmarshalError
-	assert.True(t, errors.As(err, &invalidUnmarshal))
-}
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			respondJSON(w, map[string]string{"file": "test-id"})
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &uploadAPIClient{conn: srv.Client()}
+			req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+			require.NoError(t, err)
 
-func TestUploadDo_UnhandledStatusPlainTextBody(t *testing.T) {
-	t.Parallel()
+			result := map[string]string{}
+			err = client.Do(req, result)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadGateway)
-		w.Write([]byte("upstream connect error"))
-	}))
-	defer srv.Close()
+			require.Error(t, err)
+			var invalidUnmarshal *json.InvalidUnmarshalError
+			assert.True(t, errors.As(err, &invalidUnmarshal))
+		})
+	})
 
-	client := &uploadAPIClient{conn: srv.Client()}
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
-	assert.NoError(t, err)
+	t.Run("unhandled_status_plain_text", func(t *testing.T) {
+		t.Parallel()
 
-	err = client.Do(req, nil)
+		withServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("upstream connect error"))
+		}), func(t *testing.T, srv *httptest.Server) {
+			client := &uploadAPIClient{conn: srv.Client()}
+			req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+			require.NoError(t, err)
 
-	assert.Error(t, err)
-	var apiErr APIError
-	assert.True(t, errors.As(err, &apiErr))
-	assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
-	assert.Equal(t, "upstream connect error", apiErr.Detail)
+			err = client.Do(req, nil)
+
+			require.Error(t, err)
+			var apiErr APIError
+			assert.True(t, errors.As(err, &apiErr))
+			assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
+			assert.Equal(t, "upstream connect error", apiErr.Detail)
+		})
+	})
 }

--- a/ucare/uploadapi_test.go
+++ b/ucare/uploadapi_test.go
@@ -2,6 +2,7 @@ package ucare
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -119,6 +120,28 @@ func TestUploadDo_ThrottleRetrySuccess(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "test-id", result["file"])
 	assert.Equal(t, int32(2), count.Load())
+}
+
+func TestUploadDo_SuccessRequiresPointerResdata(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"file":"test-id"}`))
+	}))
+	defer srv.Close()
+
+	client := &uploadAPIClient{conn: srv.Client()}
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/base/", nil)
+	assert.NoError(t, err)
+
+	result := map[string]string{}
+	err = client.Do(req, result)
+
+	assert.Error(t, err)
+	var invalidUnmarshal *json.InvalidUnmarshalError
+	assert.True(t, errors.As(err, &invalidUnmarshal))
 }
 
 func TestUploadDo_UnhandledStatusPlainTextBody(t *testing.T) {

--- a/upload/multipart.go
+++ b/upload/multipart.go
@@ -83,6 +83,10 @@ func (s service) Multipart(
 		return nil, err
 	}
 
+	if d.ID == "" {
+		return nil, errors.New("multipart start: server returned empty upload ID")
+	}
+
 	go d.uploadParts()
 
 	return &d, nil
@@ -121,10 +125,6 @@ const (
 )
 
 func (d *multipartData) uploadParts() {
-	if d == nil || d.ID == "" {
-		return
-	}
-
 	var wg sync.WaitGroup
 	uploadSem := make(chan struct{}, concurrentUploads)
 

--- a/upload/service.go
+++ b/upload/service.go
@@ -26,6 +26,7 @@ import (
 
 // Service describes all upload related API functionality
 type Service interface {
+	Upload(context.Context, UploadParams) (FileInfo, error)
 	File(context.Context, FileParams) (id string, err error)
 	FromURL(context.Context, FromURLParams) (FromURLData, error)
 	FileInfo(ctx context.Context, id string) (FileInfo, error)

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -17,6 +17,17 @@ type UploadParams struct {
 }
 
 func (s service) Upload(ctx context.Context, params UploadParams) (FileInfo, error) {
+	if params.Size == 0 && params.Data != nil {
+		end, err := params.Data.Seek(0, io.SeekEnd)
+		if err != nil {
+			return FileInfo{}, err
+		}
+		if _, err := params.Data.Seek(0, io.SeekStart); err != nil {
+			return FileInfo{}, err
+		}
+		params.Size = end
+	}
+
 	threshold := DefaultMultipartThreshold
 	if params.MultipartThreshold != nil {
 		threshold = *params.MultipartThreshold

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -1,0 +1,89 @@
+package upload
+
+import (
+	"context"
+	"io"
+)
+
+// DefaultMultipartThreshold is the default file size threshold for switching
+// from direct upload to multipart upload. Files larger than this value
+// will use multipart upload.
+const DefaultMultipartThreshold int64 = 10 * 1024 * 1024 // 10MB
+
+// UploadParams holds parameters for the unified Upload method.
+type UploadParams struct {
+	// Data (required) reads the data to be uploaded.
+	Data io.ReadSeeker
+	// Name (required) is the original filename.
+	Name string
+	// ContentType is the file MIME-type.
+	ContentType string
+	// Size (required) is the precise file size in bytes.
+	Size int64
+	// ToStore sets the file storing behaviour.
+	ToStore *string
+	// MultipartThreshold controls the upload method selection:
+	//   nil    → use DefaultMultipartThreshold (10MB)
+	//   > 0   → use as custom threshold
+	//   0     → force direct upload
+	//   < 0   → force multipart upload
+	MultipartThreshold *int64
+}
+
+// Upload automatically selects direct or multipart upload based on file size
+// and the configured threshold. It returns a FileInfo for the uploaded file.
+func (s service) Upload(ctx context.Context, params UploadParams) (FileInfo, error) {
+	threshold := DefaultMultipartThreshold
+	if params.MultipartThreshold != nil {
+		threshold = *params.MultipartThreshold
+	}
+
+	useMultipart := false
+	if threshold < 0 {
+		useMultipart = true
+	} else if threshold == 0 {
+		useMultipart = false
+	} else {
+		useMultipart = params.Size > threshold
+	}
+
+	if useMultipart {
+		return s.uploadMultipart(ctx, params)
+	}
+	return s.uploadDirect(ctx, params)
+}
+
+func (s service) uploadDirect(ctx context.Context, params UploadParams) (FileInfo, error) {
+	id, err := s.File(ctx, FileParams{
+		Data:        params.Data,
+		Name:        params.Name,
+		ContentType: params.ContentType,
+		ToStore:     params.ToStore,
+	})
+	if err != nil {
+		return FileInfo{}, err
+	}
+	return s.FileInfo(ctx, id)
+}
+
+func (s service) uploadMultipart(ctx context.Context, params UploadParams) (FileInfo, error) {
+	data, err := s.Multipart(ctx, MultipartParams{
+		Data:        params.Data,
+		FileName:    params.Name,
+		ContentType: params.ContentType,
+		Size:        params.Size,
+		ToStore:     params.ToStore,
+	})
+	if err != nil {
+		return FileInfo{}, err
+	}
+
+	select {
+	case info := <-data.Done():
+		return info, nil
+	case err := <-data.Error():
+		return FileInfo{}, err
+	case <-ctx.Done():
+		return FileInfo{}, ctx.Err()
+	}
+}

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -5,33 +5,17 @@ import (
 	"io"
 )
 
-// DefaultMultipartThreshold is the default file size threshold for switching
-// from direct upload to multipart upload. Files larger than this value
-// will use multipart upload.
 const DefaultMultipartThreshold int64 = 10 * 1024 * 1024 // 10MB
 
-// UploadParams holds parameters for the unified Upload method.
 type UploadParams struct {
-	// Data (required) reads the data to be uploaded.
-	Data io.ReadSeeker
-	// Name (required) is the original filename.
-	Name string
-	// ContentType is the file MIME-type.
-	ContentType string
-	// Size (required) is the precise file size in bytes.
-	Size int64
-	// ToStore sets the file storing behaviour.
-	ToStore *string
-	// MultipartThreshold controls the upload method selection:
-	//   nil    → use DefaultMultipartThreshold (10MB)
-	//   > 0   → use as custom threshold
-	//   0     → force direct upload
-	//   < 0   → force multipart upload
+	Data               io.ReadSeeker
+	Name               string
+	ContentType        string
+	Size               int64
+	ToStore            *string
 	MultipartThreshold *int64
 }
 
-// Upload automatically selects direct or multipart upload based on file size
-// and the configured threshold. It returns a FileInfo for the uploaded file.
 func (s service) Upload(ctx context.Context, params UploadParams) (FileInfo, error) {
 	threshold := DefaultMultipartThreshold
 	if params.MultipartThreshold != nil {

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -18,216 +18,131 @@ func int64Ptr(v int64) *int64 { return &v }
 func TestUpload(t *testing.T) {
 	t.Parallel()
 
-	t.Run("small_file_direct", func(t *testing.T) {
-		t.Parallel()
+	tests := []struct {
+		name       string
+		fileSize   int64
+		threshold  *int64
+		omitSize   bool
+		wantDirect bool
+	}{
+		{
+			name:       "small_file",
+			fileSize:   1 * 1024 * 1024,
+			wantDirect: true,
+		},
+		{
+			name:       "exact_threshold",
+			fileSize:   DefaultMultipartThreshold,
+			wantDirect: true,
+		},
+		{
+			name:     "above_threshold",
+			fileSize: DefaultMultipartThreshold + 1,
+		},
+		{
+			name:      "custom_threshold",
+			fileSize:  5 * 1024 * 1024,
+			threshold: int64Ptr(3 * 1024 * 1024),
+		},
+		{
+			name:       "force_direct",
+			fileSize:   DefaultMultipartThreshold + 1,
+			threshold:  int64Ptr(0),
+			wantDirect: true,
+		},
+		{
+			name:      "force_multipart",
+			fileSize:  1024,
+			threshold: int64Ptr(-1),
+		},
+		{
+			name:       "auto_size_direct",
+			fileSize:   1024,
+			omitSize:   true,
+			wantDirect: true,
+		},
+		{
+			name:     "auto_size_multipart",
+			fileSize: DefaultMultipartThreshold + 1,
+			omitSize: true,
+		},
+	}
 
-		var directHit, multipartHit atomic.Int32
-		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.URL.Path {
-			case "/base/":
-				directHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-123"})
-			case "/info/":
-				uctest.RespondJSON(t, w, FileInfo{FileName: "small.txt"})
-			case "/multipart/start/":
-				multipartHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-123", "parts": []string{}})
-			default:
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}), func(t *testing.T, srv *httptest.Server) {
-			svc := NewService(uctest.NewUploadServerClient(srv))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-			data := bytes.NewReader(make([]byte, 1*1024*1024)) // 1MB
-			info, err := svc.Upload(context.Background(), UploadParams{
-				Data: data,
-				Name: "small.txt",
-				Size: 1 * 1024 * 1024,
+			var directHit, multipartHit atomic.Int32
+			uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/base/":
+					assert.Equal(t, http.MethodPost, r.Method)
+					directHit.Add(1)
+					uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid"})
+				case "/info/":
+					uctest.RespondJSON(t, w, FileInfo{FileName: tt.name})
+				case "/multipart/start/":
+					assert.Equal(t, http.MethodPost, r.Method)
+					multipartHit.Add(1)
+					uctest.RespondJSON(t, w, map[string]any{
+						"uuid": "test-uuid", "parts": []string{},
+					})
+				case "/multipart/complete/":
+					assert.Equal(t, http.MethodPost, r.Method)
+					uctest.RespondJSON(t, w, FileInfo{FileName: tt.name})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}), func(t *testing.T, srv *httptest.Server) {
+				svc := NewService(uctest.NewUploadServerClient(srv))
+
+				params := UploadParams{
+					Data:               bytes.NewReader(make([]byte, tt.fileSize)),
+					Name:               tt.name,
+					ContentType:        "application/octet-stream",
+					MultipartThreshold: tt.threshold,
+				}
+				if !tt.omitSize {
+					params.Size = tt.fileSize
+				}
+
+				info, err := svc.Upload(context.Background(), params)
+				require.NoError(t, err)
+				assert.Equal(t, tt.name, info.FileName)
+
+				if tt.wantDirect {
+					assert.Equal(t, int32(1), directHit.Load(), "expected direct upload")
+				} else {
+					assert.Equal(t, int32(1), multipartHit.Load(), "expected multipart upload")
+				}
 			})
-
-			require.NoError(t, err)
-			assert.Equal(t, "small.txt", info.FileName)
-			assert.Equal(t, int32(1), directHit.Load())
-			assert.Equal(t, int32(0), multipartHit.Load())
 		})
-	})
+	}
 
-	t.Run("exact_threshold_direct", func(t *testing.T) {
+	t.Run("multipart_empty_uuid", func(t *testing.T) {
 		t.Parallel()
 
-		var directHit, multipartHit atomic.Int32
 		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
-			case "/base/":
-				directHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-exact"})
-			case "/info/":
-				uctest.RespondJSON(t, w, FileInfo{FileName: "exact.bin"})
 			case "/multipart/start/":
-				multipartHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-exact", "parts": []string{}})
+				assert.Equal(t, http.MethodPost, r.Method)
+				uctest.RespondJSON(t, w, map[string]interface{}{"parts": []string{}})
 			default:
 				w.WriteHeader(http.StatusNotFound)
 			}
 		}), func(t *testing.T, srv *httptest.Server) {
 			svc := NewService(uctest.NewUploadServerClient(srv))
 
-			data := bytes.NewReader(make([]byte, DefaultMultipartThreshold))
-			info, err := svc.Upload(context.Background(), UploadParams{
-				Data: data,
-				Name: "exact.bin",
-				Size: DefaultMultipartThreshold,
-			})
-
-			require.NoError(t, err)
-			assert.Equal(t, "exact.bin", info.FileName)
-			assert.Equal(t, int32(1), directHit.Load())
-			assert.Equal(t, int32(0), multipartHit.Load())
-		})
-	})
-
-	t.Run("large_file_multipart", func(t *testing.T) {
-		t.Parallel()
-
-		var directHit, multipartHit, completeHit atomic.Int32
-		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.URL.Path {
-			case "/base/":
-				directHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-456"})
-			case "/multipart/start/":
-				multipartHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-456", "parts": []string{}})
-			case "/multipart/complete/":
-				completeHit.Add(1)
-				uctest.RespondJSON(t, w, FileInfo{FileName: "large.bin"})
-			default:
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}), func(t *testing.T, srv *httptest.Server) {
-			svc := NewService(uctest.NewUploadServerClient(srv))
-
-			data := bytes.NewReader(make([]byte, 20*1024*1024)) // 20MB
-			info, err := svc.Upload(context.Background(), UploadParams{
-				Data:        data,
-				Name:        "large.bin",
+			fileSize := DefaultMultipartThreshold + 1
+			_, err := svc.Upload(context.Background(), UploadParams{
+				Data:        bytes.NewReader(make([]byte, fileSize)),
+				Name:        "bad-start.bin",
 				ContentType: "application/octet-stream",
-				Size:        20 * 1024 * 1024,
+				Size:        fileSize,
 			})
 
-			require.NoError(t, err)
-			assert.Equal(t, "large.bin", info.FileName)
-			assert.Equal(t, int32(0), directHit.Load())
-			assert.Equal(t, int32(1), multipartHit.Load())
-			assert.Equal(t, int32(1), completeHit.Load())
-		})
-	})
-
-	t.Run("custom_threshold", func(t *testing.T) {
-		t.Parallel()
-
-		var directHit, multipartHit atomic.Int32
-		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.URL.Path {
-			case "/base/":
-				directHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-789"})
-			case "/multipart/start/":
-				multipartHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-789", "parts": []string{}})
-			case "/multipart/complete/":
-				uctest.RespondJSON(t, w, FileInfo{FileName: "medium.bin"})
-			default:
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}), func(t *testing.T, srv *httptest.Server) {
-			svc := NewService(uctest.NewUploadServerClient(srv))
-
-			data := bytes.NewReader(make([]byte, 5*1024*1024)) // 5MB
-			threshold := int64(3 * 1024 * 1024)                // 3MB threshold
-			info, err := svc.Upload(context.Background(), UploadParams{
-				Data:               data,
-				Name:               "medium.bin",
-				ContentType:        "application/octet-stream",
-				Size:               5 * 1024 * 1024,
-				MultipartThreshold: &threshold,
-			})
-
-			require.NoError(t, err)
-			assert.Equal(t, "medium.bin", info.FileName)
-			assert.Equal(t, int32(0), directHit.Load())
-			assert.Equal(t, int32(1), multipartHit.Load())
-		})
-	})
-
-	t.Run("force_direct", func(t *testing.T) {
-		t.Parallel()
-
-		var directHit, multipartHit atomic.Int32
-		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.URL.Path {
-			case "/base/":
-				directHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-force-direct"})
-			case "/info/":
-				uctest.RespondJSON(t, w, FileInfo{FileName: "forced-direct.bin"})
-			case "/multipart/start/":
-				multipartHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-force-direct", "parts": []string{}})
-			default:
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}), func(t *testing.T, srv *httptest.Server) {
-			svc := NewService(uctest.NewUploadServerClient(srv))
-
-			data := bytes.NewReader(make([]byte, 20*1024*1024)) // 20MB, normally multipart
-			info, err := svc.Upload(context.Background(), UploadParams{
-				Data:               data,
-				Name:               "forced-direct.bin",
-				Size:               20 * 1024 * 1024,
-				MultipartThreshold: int64Ptr(0),
-			})
-
-			require.NoError(t, err)
-			assert.Equal(t, "forced-direct.bin", info.FileName)
-			assert.Equal(t, int32(1), directHit.Load())
-			assert.Equal(t, int32(0), multipartHit.Load())
-		})
-	})
-
-	t.Run("force_multipart", func(t *testing.T) {
-		t.Parallel()
-
-		var directHit, multipartHit atomic.Int32
-		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.URL.Path {
-			case "/base/":
-				directHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-force-multi"})
-			case "/multipart/start/":
-				multipartHit.Add(1)
-				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-force-multi", "parts": []string{}})
-			case "/multipart/complete/":
-				uctest.RespondJSON(t, w, FileInfo{FileName: "forced-multi.txt"})
-			default:
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}), func(t *testing.T, srv *httptest.Server) {
-			svc := NewService(uctest.NewUploadServerClient(srv))
-
-			data := bytes.NewReader(make([]byte, 1024)) // 1KB, normally direct
-			info, err := svc.Upload(context.Background(), UploadParams{
-				Data:               data,
-				Name:               "forced-multi.txt",
-				ContentType:        "text/plain",
-				Size:               1024,
-				MultipartThreshold: int64Ptr(-1),
-			})
-
-			require.NoError(t, err)
-			assert.Equal(t, "forced-multi.txt", info.FileName)
-			assert.Equal(t, int32(0), directHit.Load())
-			assert.Equal(t, int32(1), multipartHit.Load())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "empty upload ID")
 		})
 	})
 }

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -3,312 +3,231 @@ package upload
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 
-	assert "github.com/stretchr/testify/require"
-	"github.com/uploadcare/uploadcare-go/v2/internal/config"
-	"github.com/uploadcare/uploadcare-go/v2/ucare"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uploadcare/uploadcare-go/v2/internal/uctest"
 )
-
-type mockUploadClient struct {
-	baseURL string
-	conn    *http.Client
-}
-
-func (c *mockUploadClient) NewRequest(
-	ctx context.Context,
-	_ config.Endpoint,
-	method string,
-	requrl string,
-	data ucare.ReqEncoder,
-) (*http.Request, error) {
-	fullURL := c.baseURL + requrl
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	ctx = context.WithValue(ctx, config.CtxAuthFuncKey, ucare.UploadAPIAuthFunc(
-		func() (string, *string, *int64) {
-			return "testpubkey", nil, nil
-		},
-	))
-	req = req.WithContext(ctx)
-	if data != nil {
-		if err := data.EncodeReq(req); err != nil {
-			return nil, err
-		}
-	}
-	return req, nil
-}
-
-func (c *mockUploadClient) Do(req *http.Request, resdata interface{}) error {
-	resp, err := c.conn.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resdata != nil {
-		return json.NewDecoder(resp.Body).Decode(resdata)
-	}
-	return nil
-}
 
 func int64Ptr(v int64) *int64 { return &v }
 
-func TestUpload_SmallFile_DirectUpload(t *testing.T) {
+func TestUpload(t *testing.T) {
 	t.Parallel()
 
-	var directHit, multipartHit atomic.Int32
-	fileID := "test-uuid-123"
+	t.Run("small_file_direct", func(t *testing.T) {
+		t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/base/":
-			directHit.Add(1)
-			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
-		case "/info/":
-			json.NewEncoder(w).Encode(FileInfo{FileName: "small.txt"})
-		case "/multipart/start/":
-			multipartHit.Add(1)
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"uuid": fileID, "parts": []string{}})
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
+		var directHit, multipartHit atomic.Int32
+		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/base/":
+				directHit.Add(1)
+				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-123"})
+			case "/info/":
+				uctest.RespondJSON(w, FileInfo{FileName: "small.txt"})
+			case "/multipart/start/":
+				multipartHit.Add(1)
+				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-123", "parts": []string{}})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}), func(t *testing.T, srv *httptest.Server) {
+			svc := NewService(uctest.NewUploadServerClient(srv))
 
-	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
-	svc := NewService(client)
-
-	data := bytes.NewReader(make([]byte, 1*1024*1024)) // 1MB
-	info, err := svc.Upload(context.Background(), UploadParams{
-		Data: data,
-		Name: "small.txt",
-		Size: 1 * 1024 * 1024,
-	})
-
-	assert.NoError(t, err)
-	assert.Equal(t, "small.txt", info.FileName)
-	assert.Equal(t, int32(1), directHit.Load())
-	assert.Equal(t, int32(0), multipartHit.Load())
-}
-
-func TestUpload_ExactThreshold_DirectUpload(t *testing.T) {
-	t.Parallel()
-
-	var directHit, multipartHit atomic.Int32
-	fileID := "test-uuid-exact"
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/base/":
-			directHit.Add(1)
-			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
-		case "/info/":
-			json.NewEncoder(w).Encode(FileInfo{FileName: "exact.bin"})
-		case "/multipart/start/":
-			multipartHit.Add(1)
-			json.NewEncoder(w).Encode(map[string]interface{}{"uuid": fileID, "parts": []string{}})
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
-
-	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
-	svc := NewService(client)
-
-	// File size exactly at DefaultMultipartThreshold → should use direct upload
-	data := bytes.NewReader(make([]byte, DefaultMultipartThreshold))
-	info, err := svc.Upload(context.Background(), UploadParams{
-		Data: data,
-		Name: "exact.bin",
-		Size: DefaultMultipartThreshold,
-	})
-
-	assert.NoError(t, err)
-	assert.Equal(t, "exact.bin", info.FileName)
-	assert.Equal(t, int32(1), directHit.Load())
-	assert.Equal(t, int32(0), multipartHit.Load())
-}
-
-func TestUpload_LargeFile_MultipartUpload(t *testing.T) {
-	t.Parallel()
-
-	var directHit, multipartHit, completeHit atomic.Int32
-	fileID := "test-uuid-456"
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/base/":
-			directHit.Add(1)
-			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
-		case "/multipart/start/":
-			multipartHit.Add(1)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"uuid":  fileID,
-				"parts": []string{},
+			data := bytes.NewReader(make([]byte, 1*1024*1024)) // 1MB
+			info, err := svc.Upload(context.Background(), UploadParams{
+				Data: data,
+				Name: "small.txt",
+				Size: 1 * 1024 * 1024,
 			})
-		case "/multipart/complete/":
-			completeHit.Add(1)
-			json.NewEncoder(w).Encode(FileInfo{FileName: "large.bin"})
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
 
-	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
-	svc := NewService(client)
-
-	data := bytes.NewReader(make([]byte, 20*1024*1024)) // 20MB
-	info, err := svc.Upload(context.Background(), UploadParams{
-		Data:        data,
-		Name:        "large.bin",
-		ContentType: "application/octet-stream",
-		Size:        20 * 1024 * 1024,
+			require.NoError(t, err)
+			assert.Equal(t, "small.txt", info.FileName)
+			assert.Equal(t, int32(1), directHit.Load())
+			assert.Equal(t, int32(0), multipartHit.Load())
+		})
 	})
 
-	assert.NoError(t, err)
-	assert.Equal(t, "large.bin", info.FileName)
-	assert.Equal(t, int32(0), directHit.Load())
-	assert.Equal(t, int32(1), multipartHit.Load())
-	assert.Equal(t, int32(1), completeHit.Load())
-}
+	t.Run("exact_threshold_direct", func(t *testing.T) {
+		t.Parallel()
 
-func TestUpload_CustomThreshold(t *testing.T) {
-	t.Parallel()
+		var directHit, multipartHit atomic.Int32
+		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/base/":
+				directHit.Add(1)
+				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-exact"})
+			case "/info/":
+				uctest.RespondJSON(w, FileInfo{FileName: "exact.bin"})
+			case "/multipart/start/":
+				multipartHit.Add(1)
+				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-exact", "parts": []string{}})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}), func(t *testing.T, srv *httptest.Server) {
+			svc := NewService(uctest.NewUploadServerClient(srv))
 
-	var directHit, multipartHit atomic.Int32
-	fileID := "test-uuid-789"
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/base/":
-			directHit.Add(1)
-			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
-		case "/multipart/start/":
-			multipartHit.Add(1)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"uuid":  fileID,
-				"parts": []string{},
+			data := bytes.NewReader(make([]byte, DefaultMultipartThreshold))
+			info, err := svc.Upload(context.Background(), UploadParams{
+				Data: data,
+				Name: "exact.bin",
+				Size: DefaultMultipartThreshold,
 			})
-		case "/multipart/complete/":
-			json.NewEncoder(w).Encode(FileInfo{FileName: "medium.bin"})
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
 
-	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
-	svc := NewService(client)
-
-	data := bytes.NewReader(make([]byte, 5*1024*1024)) // 5MB
-	threshold := int64(3 * 1024 * 1024)                // 3MB threshold
-	info, err := svc.Upload(context.Background(), UploadParams{
-		Data:               data,
-		Name:               "medium.bin",
-		ContentType:        "application/octet-stream",
-		Size:               5 * 1024 * 1024,
-		MultipartThreshold: &threshold,
+			require.NoError(t, err)
+			assert.Equal(t, "exact.bin", info.FileName)
+			assert.Equal(t, int32(1), directHit.Load())
+			assert.Equal(t, int32(0), multipartHit.Load())
+		})
 	})
 
-	assert.NoError(t, err)
-	assert.Equal(t, "medium.bin", info.FileName)
-	assert.Equal(t, int32(0), directHit.Load())
-	assert.Equal(t, int32(1), multipartHit.Load())
-}
+	t.Run("large_file_multipart", func(t *testing.T) {
+		t.Parallel()
 
-func TestUpload_ForceDirectUpload(t *testing.T) {
-	t.Parallel()
+		var directHit, multipartHit, completeHit atomic.Int32
+		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/base/":
+				directHit.Add(1)
+				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-456"})
+			case "/multipart/start/":
+				multipartHit.Add(1)
+				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-456", "parts": []string{}})
+			case "/multipart/complete/":
+				completeHit.Add(1)
+				uctest.RespondJSON(w, FileInfo{FileName: "large.bin"})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}), func(t *testing.T, srv *httptest.Server) {
+			svc := NewService(uctest.NewUploadServerClient(srv))
 
-	var directHit, multipartHit atomic.Int32
-	fileID := "test-uuid-force-direct"
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/base/":
-			directHit.Add(1)
-			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
-		case "/info/":
-			json.NewEncoder(w).Encode(FileInfo{FileName: "forced-direct.bin"})
-		case "/multipart/start/":
-			multipartHit.Add(1)
-			json.NewEncoder(w).Encode(map[string]interface{}{"uuid": fileID, "parts": []string{}})
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
-
-	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
-	svc := NewService(client)
-
-	data := bytes.NewReader(make([]byte, 20*1024*1024)) // 20MB, normally multipart
-	info, err := svc.Upload(context.Background(), UploadParams{
-		Data:               data,
-		Name:               "forced-direct.bin",
-		Size:               20 * 1024 * 1024,
-		MultipartThreshold: int64Ptr(0), // force direct
-	})
-
-	assert.NoError(t, err)
-	assert.Equal(t, "forced-direct.bin", info.FileName)
-	assert.Equal(t, int32(1), directHit.Load())
-	assert.Equal(t, int32(0), multipartHit.Load())
-}
-
-func TestUpload_ForceMultipartUpload(t *testing.T) {
-	t.Parallel()
-
-	var directHit, multipartHit atomic.Int32
-	fileID := "test-uuid-force-multi"
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/base/":
-			directHit.Add(1)
-			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
-		case "/multipart/start/":
-			multipartHit.Add(1)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"uuid":  fileID,
-				"parts": []string{},
+			data := bytes.NewReader(make([]byte, 20*1024*1024)) // 20MB
+			info, err := svc.Upload(context.Background(), UploadParams{
+				Data:        data,
+				Name:        "large.bin",
+				ContentType: "application/octet-stream",
+				Size:        20 * 1024 * 1024,
 			})
-		case "/multipart/complete/":
-			json.NewEncoder(w).Encode(FileInfo{FileName: "forced-multi.txt"})
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
 
-	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
-	svc := NewService(client)
-
-	data := bytes.NewReader(make([]byte, 1024)) // 1KB, normally direct
-	info, err := svc.Upload(context.Background(), UploadParams{
-		Data:               data,
-		Name:               "forced-multi.txt",
-		ContentType:        "text/plain",
-		Size:               1024,
-		MultipartThreshold: int64Ptr(-1), // force multipart
+			require.NoError(t, err)
+			assert.Equal(t, "large.bin", info.FileName)
+			assert.Equal(t, int32(0), directHit.Load())
+			assert.Equal(t, int32(1), multipartHit.Load())
+			assert.Equal(t, int32(1), completeHit.Load())
+		})
 	})
 
-	assert.NoError(t, err)
-	assert.Equal(t, "forced-multi.txt", info.FileName)
-	assert.Equal(t, int32(0), directHit.Load())
-	assert.Equal(t, int32(1), multipartHit.Load())
+	t.Run("custom_threshold", func(t *testing.T) {
+		t.Parallel()
+
+		var directHit, multipartHit atomic.Int32
+		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/base/":
+				directHit.Add(1)
+				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-789"})
+			case "/multipart/start/":
+				multipartHit.Add(1)
+				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-789", "parts": []string{}})
+			case "/multipart/complete/":
+				uctest.RespondJSON(w, FileInfo{FileName: "medium.bin"})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}), func(t *testing.T, srv *httptest.Server) {
+			svc := NewService(uctest.NewUploadServerClient(srv))
+
+			data := bytes.NewReader(make([]byte, 5*1024*1024)) // 5MB
+			threshold := int64(3 * 1024 * 1024)                // 3MB threshold
+			info, err := svc.Upload(context.Background(), UploadParams{
+				Data:               data,
+				Name:               "medium.bin",
+				ContentType:        "application/octet-stream",
+				Size:               5 * 1024 * 1024,
+				MultipartThreshold: &threshold,
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, "medium.bin", info.FileName)
+			assert.Equal(t, int32(0), directHit.Load())
+			assert.Equal(t, int32(1), multipartHit.Load())
+		})
+	})
+
+	t.Run("force_direct", func(t *testing.T) {
+		t.Parallel()
+
+		var directHit, multipartHit atomic.Int32
+		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/base/":
+				directHit.Add(1)
+				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-force-direct"})
+			case "/info/":
+				uctest.RespondJSON(w, FileInfo{FileName: "forced-direct.bin"})
+			case "/multipart/start/":
+				multipartHit.Add(1)
+				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-force-direct", "parts": []string{}})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}), func(t *testing.T, srv *httptest.Server) {
+			svc := NewService(uctest.NewUploadServerClient(srv))
+
+			data := bytes.NewReader(make([]byte, 20*1024*1024)) // 20MB, normally multipart
+			info, err := svc.Upload(context.Background(), UploadParams{
+				Data:               data,
+				Name:               "forced-direct.bin",
+				Size:               20 * 1024 * 1024,
+				MultipartThreshold: int64Ptr(0),
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, "forced-direct.bin", info.FileName)
+			assert.Equal(t, int32(1), directHit.Load())
+			assert.Equal(t, int32(0), multipartHit.Load())
+		})
+	})
+
+	t.Run("force_multipart", func(t *testing.T) {
+		t.Parallel()
+
+		var directHit, multipartHit atomic.Int32
+		uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/base/":
+				directHit.Add(1)
+				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-force-multi"})
+			case "/multipart/start/":
+				multipartHit.Add(1)
+				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-force-multi", "parts": []string{}})
+			case "/multipart/complete/":
+				uctest.RespondJSON(w, FileInfo{FileName: "forced-multi.txt"})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}), func(t *testing.T, srv *httptest.Server) {
+			svc := NewService(uctest.NewUploadServerClient(srv))
+
+			data := bytes.NewReader(make([]byte, 1024)) // 1KB, normally direct
+			info, err := svc.Upload(context.Background(), UploadParams{
+				Data:               data,
+				Name:               "forced-multi.txt",
+				ContentType:        "text/plain",
+				Size:               1024,
+				MultipartThreshold: int64Ptr(-1),
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, "forced-multi.txt", info.FileName)
+			assert.Equal(t, int32(0), directHit.Load())
+			assert.Equal(t, int32(1), multipartHit.Load())
+		})
+	})
 }

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -1,0 +1,313 @@
+package upload
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	"github.com/uploadcare/uploadcare-go/v2/internal/config"
+	"github.com/uploadcare/uploadcare-go/v2/ucare"
+)
+
+type mockUploadClient struct {
+	baseURL string
+	conn    *http.Client
+}
+
+func (c *mockUploadClient) NewRequest(
+	ctx context.Context,
+	_ config.Endpoint,
+	method string,
+	requrl string,
+	data ucare.ReqEncoder,
+) (*http.Request, error) {
+	fullURL := c.baseURL + requrl
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	ctx = context.WithValue(ctx, config.CtxAuthFuncKey, ucare.UploadAPIAuthFunc(
+		func() (string, *string, *int64) {
+			return "testpubkey", nil, nil
+		},
+	))
+	req = req.WithContext(ctx)
+	if data != nil {
+		if err := data.EncodeReq(req); err != nil {
+			return nil, err
+		}
+	}
+	return req, nil
+}
+
+func (c *mockUploadClient) Do(req *http.Request, resdata interface{}) error {
+	resp, err := c.conn.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resdata != nil {
+		return json.NewDecoder(resp.Body).Decode(resdata)
+	}
+	return nil
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func TestUpload_SmallFile_DirectUpload(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit atomic.Int32
+	fileID := "test-uuid-123"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/info/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "small.txt"})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"uuid": fileID, "parts": []string{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	data := bytes.NewReader(make([]byte, 1*1024*1024)) // 1MB
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data: data,
+		Name: "small.txt",
+		Size: 1 * 1024 * 1024,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "small.txt", info.FileName)
+	assert.Equal(t, int32(1), directHit.Load())
+	assert.Equal(t, int32(0), multipartHit.Load())
+}
+
+func TestUpload_ExactThreshold_DirectUpload(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit atomic.Int32
+	fileID := "test-uuid-exact"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/info/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "exact.bin"})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]interface{}{"uuid": fileID, "parts": []string{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	// File size exactly at DefaultMultipartThreshold → should use direct upload
+	data := bytes.NewReader(make([]byte, DefaultMultipartThreshold))
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data: data,
+		Name: "exact.bin",
+		Size: DefaultMultipartThreshold,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "exact.bin", info.FileName)
+	assert.Equal(t, int32(1), directHit.Load())
+	assert.Equal(t, int32(0), multipartHit.Load())
+}
+
+func TestUpload_LargeFile_MultipartUpload(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit, completeHit atomic.Int32
+	fileID := "test-uuid-456"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":  fileID,
+				"parts": []string{},
+			})
+		case "/multipart/complete/":
+			completeHit.Add(1)
+			json.NewEncoder(w).Encode(FileInfo{FileName: "large.bin"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	data := bytes.NewReader(make([]byte, 20*1024*1024)) // 20MB
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data:        data,
+		Name:        "large.bin",
+		ContentType: "application/octet-stream",
+		Size:        20 * 1024 * 1024,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "large.bin", info.FileName)
+	assert.Equal(t, int32(0), directHit.Load())
+	assert.Equal(t, int32(1), multipartHit.Load())
+}
+
+func TestUpload_CustomThreshold(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit atomic.Int32
+	fileID := "test-uuid-789"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":  fileID,
+				"parts": []string{},
+			})
+		case "/multipart/complete/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "medium.bin"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	data := bytes.NewReader(make([]byte, 5*1024*1024)) // 5MB
+	threshold := int64(3 * 1024 * 1024)                // 3MB threshold
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data:               data,
+		Name:               "medium.bin",
+		ContentType:        "application/octet-stream",
+		Size:               5 * 1024 * 1024,
+		MultipartThreshold: &threshold,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "medium.bin", info.FileName)
+	assert.Equal(t, int32(0), directHit.Load())
+	assert.Equal(t, int32(1), multipartHit.Load())
+}
+
+func TestUpload_ForceDirectUpload(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit atomic.Int32
+	fileID := "test-uuid-force-direct"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/info/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "forced-direct.bin"})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]interface{}{"uuid": fileID, "parts": []string{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	data := bytes.NewReader(make([]byte, 20*1024*1024)) // 20MB, normally multipart
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data:               data,
+		Name:               "forced-direct.bin",
+		Size:               20 * 1024 * 1024,
+		MultipartThreshold: int64Ptr(0), // force direct
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "forced-direct.bin", info.FileName)
+	assert.Equal(t, int32(1), directHit.Load())
+	assert.Equal(t, int32(0), multipartHit.Load())
+}
+
+func TestUpload_ForceMultipartUpload(t *testing.T) {
+	t.Parallel()
+
+	var directHit, multipartHit atomic.Int32
+	fileID := "test-uuid-force-multi"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/base/":
+			directHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"file": fileID})
+		case "/multipart/start/":
+			multipartHit.Add(1)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":  fileID,
+				"parts": []string{},
+			})
+		case "/multipart/complete/":
+			json.NewEncoder(w).Encode(FileInfo{FileName: "forced-multi.txt"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &mockUploadClient{baseURL: srv.URL, conn: srv.Client()}
+	svc := NewService(client)
+
+	data := bytes.NewReader(make([]byte, 1024)) // 1KB, normally direct
+	info, err := svc.Upload(context.Background(), UploadParams{
+		Data:               data,
+		Name:               "forced-multi.txt",
+		ContentType:        "text/plain",
+		Size:               1024,
+		MultipartThreshold: int64Ptr(-1), // force multipart
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "forced-multi.txt", info.FileName)
+	assert.Equal(t, int32(0), directHit.Load())
+	assert.Equal(t, int32(1), multipartHit.Load())
+}

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -26,12 +26,12 @@ func TestUpload(t *testing.T) {
 			switch r.URL.Path {
 			case "/base/":
 				directHit.Add(1)
-				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-123"})
+				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-123"})
 			case "/info/":
-				uctest.RespondJSON(w, FileInfo{FileName: "small.txt"})
+				uctest.RespondJSON(t, w, FileInfo{FileName: "small.txt"})
 			case "/multipart/start/":
 				multipartHit.Add(1)
-				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-123", "parts": []string{}})
+				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-123", "parts": []string{}})
 			default:
 				w.WriteHeader(http.StatusNotFound)
 			}
@@ -60,12 +60,12 @@ func TestUpload(t *testing.T) {
 			switch r.URL.Path {
 			case "/base/":
 				directHit.Add(1)
-				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-exact"})
+				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-exact"})
 			case "/info/":
-				uctest.RespondJSON(w, FileInfo{FileName: "exact.bin"})
+				uctest.RespondJSON(t, w, FileInfo{FileName: "exact.bin"})
 			case "/multipart/start/":
 				multipartHit.Add(1)
-				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-exact", "parts": []string{}})
+				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-exact", "parts": []string{}})
 			default:
 				w.WriteHeader(http.StatusNotFound)
 			}
@@ -94,13 +94,13 @@ func TestUpload(t *testing.T) {
 			switch r.URL.Path {
 			case "/base/":
 				directHit.Add(1)
-				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-456"})
+				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-456"})
 			case "/multipart/start/":
 				multipartHit.Add(1)
-				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-456", "parts": []string{}})
+				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-456", "parts": []string{}})
 			case "/multipart/complete/":
 				completeHit.Add(1)
-				uctest.RespondJSON(w, FileInfo{FileName: "large.bin"})
+				uctest.RespondJSON(t, w, FileInfo{FileName: "large.bin"})
 			default:
 				w.WriteHeader(http.StatusNotFound)
 			}
@@ -131,12 +131,12 @@ func TestUpload(t *testing.T) {
 			switch r.URL.Path {
 			case "/base/":
 				directHit.Add(1)
-				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-789"})
+				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-789"})
 			case "/multipart/start/":
 				multipartHit.Add(1)
-				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-789", "parts": []string{}})
+				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-789", "parts": []string{}})
 			case "/multipart/complete/":
-				uctest.RespondJSON(w, FileInfo{FileName: "medium.bin"})
+				uctest.RespondJSON(t, w, FileInfo{FileName: "medium.bin"})
 			default:
 				w.WriteHeader(http.StatusNotFound)
 			}
@@ -168,12 +168,12 @@ func TestUpload(t *testing.T) {
 			switch r.URL.Path {
 			case "/base/":
 				directHit.Add(1)
-				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-force-direct"})
+				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-force-direct"})
 			case "/info/":
-				uctest.RespondJSON(w, FileInfo{FileName: "forced-direct.bin"})
+				uctest.RespondJSON(t, w, FileInfo{FileName: "forced-direct.bin"})
 			case "/multipart/start/":
 				multipartHit.Add(1)
-				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-force-direct", "parts": []string{}})
+				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-force-direct", "parts": []string{}})
 			default:
 				w.WriteHeader(http.StatusNotFound)
 			}
@@ -203,12 +203,12 @@ func TestUpload(t *testing.T) {
 			switch r.URL.Path {
 			case "/base/":
 				directHit.Add(1)
-				uctest.RespondJSON(w, map[string]string{"file": "test-uuid-force-multi"})
+				uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-force-multi"})
 			case "/multipart/start/":
 				multipartHit.Add(1)
-				uctest.RespondJSON(w, map[string]interface{}{"uuid": "test-uuid-force-multi", "parts": []string{}})
+				uctest.RespondJSON(t, w, map[string]interface{}{"uuid": "test-uuid-force-multi", "parts": []string{}})
 			case "/multipart/complete/":
-				uctest.RespondJSON(w, FileInfo{FileName: "forced-multi.txt"})
+				uctest.RespondJSON(t, w, FileInfo{FileName: "forced-multi.txt"})
 			default:
 				w.WriteHeader(http.StatusNotFound)
 			}

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -181,6 +181,7 @@ func TestUpload_LargeFile_MultipartUpload(t *testing.T) {
 	assert.Equal(t, "large.bin", info.FileName)
 	assert.Equal(t, int32(0), directHit.Load())
 	assert.Equal(t, int32(1), multipartHit.Load())
+	assert.Equal(t, int32(1), completeHit.Load())
 }
 
 func TestUpload_CustomThreshold(t *testing.T) {


### PR DESCRIPTION
- add configurable throttling retry behavior via `ucare.Config.Retry`
- export structured API error types with status details for CLI inspection
- add `upload.Service.Upload()` with automatic direct-vs-multipart selection and changelog updates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Throttled requests (HTTP 429) no longer retry automatically by default; retries are opt-in via client configuration.

* **New Features**
  * Exported structured API errors that include HTTP status and detail (auth, throttle, validation, forbidden).
  * Configurable throttling retry settings (max attempts, max wait).
  * Upload API: new Upload(...) chooses direct vs multipart automatically.

* **Improvements**
  * Retry logic honors Retry-After, falls back to exponential backoff (capped), respects context cancellation, and surfaces HTTP status details in errors.

* **Documentation**
  * CHANGELOG updated to reflect throttling, retry, and upload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->