### PR TITLE
Phase 4: SDK CLI gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ BREAKING CHANGES:
 * Remove `file.Copy()` method and `file.CopyParams` type — use `LocalCopy()` and `RemoteCopy()`
 * Remove `file.OrderBySizeAsc` and `file.OrderBySizeDesc` constants (not supported in v0.7)
 * Remove `APIv05` and `APIv06` constants
+* Change `file.Service.Info()` signature to accept `*file.InfoParams` for optional `include` query parameters
+* Change `webhook.Service.Delete()` to delete by webhook ID instead of target URL
 * Minimum Go version is now 1.25
 * Throttled requests no longer retry by default — automatic retries are now opt-in via `ucare.Config.Retry`
 
@@ -22,11 +24,16 @@ FEATURES:
 * Add webhook event constants for `file.stored`, `file.deleted`, `file.info_updated`, and deprecated `file.infected`
 * Add `ucare.Config.Retry` and `RetryConfig` for configurable throttling retries
 * Add `upload.Service.Upload()` for automatic direct-vs-multipart upload selection
+* Add upload metadata support for direct, multipart, from-URL, and unified uploads
+* Add `file.InfoParams.Include` and `file.ListParams.Include` for `include=appdata`
+* Add `conversion.Params.SaveInGroup` for document conversions that should persist image output as a file group
+* Add `conversion.BuildDocumentPath()` and `conversion.BuildVideoPath()` helpers for constructing conversion paths
 * Export structured API error types: `APIError`, `AuthError`, `ThrottleError`, `ValidationError`, and `ForbiddenError`
 
 IMPROVEMENTS:
 
 * Add `UserAgent` field to `ucare.Config` for custom agent identification
+* Extend form/query encoding to support Upload API metadata fields in `metadata[key]=value` bracket notation
 * Replace `http.NewRequest` + `WithContext` with `http.NewRequestWithContext`
 * Throttle retry loops now respect context cancellation
 * Throttle retries use server `Retry-After` when present, falling back to exponential backoff (capped at 30s); `MaxWaitSeconds` caps the effective wait from either source
@@ -36,7 +43,7 @@ IMPROVEMENTS:
 * Update `stretchr/testify` to v1.10.0
 * Update CI: Go 1.25, modern GitHub Actions versions, remove deprecated golint
 * Integration tests skip gracefully when credentials are not set
-* Fix errors in package documentation examples
+* Fix errors in package documentation examples and update public examples for the new `file.Info()` signature
 
 ## 1.2.1 (September 1, 2020)
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Acquiring file-specific info:
 
 ```go
 fileID := ids[0]
-file, err := fileSvc.Info(context.Background(), fileID)
+file, err := fileSvc.Info(context.Background(), fileID, nil)
 if err != nil {
 	// handle error
 }

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -42,6 +42,9 @@ type Params struct {
 	//	conversion.ToStoreTrue
 	//	conversion.ToStoreFalse
 	ToStore *string `json:"store"`
+
+	// SaveInGroup saves a multi-page image conversion result as a file group.
+	SaveInGroup *string `json:"save_in_group,omitempty"`
 }
 
 // EncodeReq implements ucare.ReqEncoder

--- a/conversion/conversion_test.go
+++ b/conversion/conversion_test.go
@@ -6,52 +6,55 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uploadcare/uploadcare-go/v2/ucare"
 )
 
-func TestConversionParams_WithSaveInGroup(t *testing.T) {
+func TestConversionParams_Encode(t *testing.T) {
 	t.Parallel()
 
-	req, err := http.NewRequest(http.MethodPost, "https://example.test/convert/document/", nil)
-	assert.NoError(t, err)
-
-	params := Params{
-		Paths:       []string{"uuid/document/-/format/png/"},
-		ToStore:     ucare.String(ToStoreTrue),
-		SaveInGroup: ucare.String("1"),
+	tests := []struct {
+		name   string
+		params Params
+		want   string
+	}{
+		{
+			name: "with_save_in_group",
+			params: Params{
+				Paths:       []string{"uuid/document/-/format/png/"},
+				ToStore:     ucare.String(ToStoreTrue),
+				SaveInGroup: ucare.String("1"),
+			},
+			want: `{
+				"paths": ["uuid/document/-/format/png/"],
+				"store": "1",
+				"save_in_group": "1"
+			}`,
+		},
+		{
+			name: "without_save_in_group",
+			params: Params{
+				Paths:   []string{"uuid/document/-/format/pdf/"},
+				ToStore: ucare.String(ToStoreFalse),
+			},
+			want: `{
+				"paths": ["uuid/document/-/format/pdf/"],
+				"store": "0"
+			}`,
+		},
 	}
 
-	err = params.EncodeReq(req)
-	assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	body, err := io.ReadAll(req.Body)
-	assert.NoError(t, err)
-	assert.JSONEq(t, `{
-		"paths": ["uuid/document/-/format/png/"],
-		"store": "1",
-		"save_in_group": "1"
-	}`, string(body))
-}
+			req, err := http.NewRequest(http.MethodPost, "https://example.test/convert/document/", nil)
+			require.NoError(t, err)
+			require.NoError(t, tt.params.EncodeReq(req))
 
-func TestConversionParams_WithoutSaveInGroup(t *testing.T) {
-	t.Parallel()
-
-	req, err := http.NewRequest(http.MethodPost, "https://example.test/convert/document/", nil)
-	assert.NoError(t, err)
-
-	params := Params{
-		Paths:   []string{"uuid/document/-/format/pdf/"},
-		ToStore: ucare.String(ToStoreFalse),
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, string(body))
+		})
 	}
-
-	err = params.EncodeReq(req)
-	assert.NoError(t, err)
-
-	body, err := io.ReadAll(req.Body)
-	assert.NoError(t, err)
-	assert.JSONEq(t, `{
-		"paths": ["uuid/document/-/format/pdf/"],
-		"store": "0"
-	}`, string(body))
-	assert.NotContains(t, string(body), "save_in_group")
 }

--- a/conversion/conversion_test.go
+++ b/conversion/conversion_test.go
@@ -1,0 +1,57 @@
+package conversion
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uploadcare/uploadcare-go/v2/ucare"
+)
+
+func TestConversionParams_WithSaveInGroup(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/convert/document/", nil)
+	assert.NoError(t, err)
+
+	params := Params{
+		Paths:       []string{"uuid/document/-/format/png/"},
+		ToStore:     ucare.String(ToStoreTrue),
+		SaveInGroup: ucare.String("1"),
+	}
+
+	err = params.EncodeReq(req)
+	assert.NoError(t, err)
+
+	body, err := io.ReadAll(req.Body)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"paths": ["uuid/document/-/format/png/"],
+		"store": "1",
+		"save_in_group": "1"
+	}`, string(body))
+}
+
+func TestConversionParams_WithoutSaveInGroup(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/convert/document/", nil)
+	assert.NoError(t, err)
+
+	params := Params{
+		Paths:   []string{"uuid/document/-/format/pdf/"},
+		ToStore: ucare.String(ToStoreFalse),
+	}
+
+	err = params.EncodeReq(req)
+	assert.NoError(t, err)
+
+	body, err := io.ReadAll(req.Body)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"paths": ["uuid/document/-/format/pdf/"],
+		"store": "0"
+	}`, string(body))
+	assert.NotContains(t, string(body), "save_in_group")
+}

--- a/conversion/path.go
+++ b/conversion/path.go
@@ -1,0 +1,80 @@
+package conversion
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DocumentPathOptions holds options for building a document conversion path.
+type DocumentPathOptions struct {
+	// UUID is the source file UUID.
+	UUID string
+	// Format is the target document format. Defaults to "pdf" when empty.
+	Format string
+	// Page extracts a single page when greater than zero.
+	Page int
+}
+
+// BuildDocumentPath constructs a document conversion path.
+func BuildDocumentPath(opts DocumentPathOptions) string {
+	format := opts.Format
+	if format == "" {
+		format = "pdf"
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s/document/-/format/%s/", opts.UUID, format)
+
+	if opts.Page > 0 {
+		fmt.Fprintf(&b, "-/page/%d/", opts.Page)
+	}
+
+	return b.String()
+}
+
+// VideoPathOptions holds options for building a video conversion path.
+type VideoPathOptions struct {
+	// UUID is the source file UUID.
+	UUID string
+	// Format is the target video format.
+	Format string
+	// Size is the output dimensions, for example "640x480".
+	Size string
+	// ResizeMode controls how the video is resized.
+	ResizeMode string
+	// Quality controls output quality.
+	Quality string
+	// CutStart is the start time for cutting.
+	CutStart string
+	// CutLength is the duration to cut.
+	CutLength string
+	// Thumbs is the number of thumbnails to generate.
+	Thumbs int
+}
+
+// BuildVideoPath constructs a video conversion path.
+func BuildVideoPath(opts VideoPathOptions) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s/video/-/format/%s/", opts.UUID, opts.Format)
+
+	if opts.Size != "" {
+		fmt.Fprintf(&b, "-/size/%s/", opts.Size)
+		if opts.ResizeMode != "" {
+			fmt.Fprintf(&b, "%s/", opts.ResizeMode)
+		}
+	}
+
+	if opts.Quality != "" {
+		fmt.Fprintf(&b, "-/quality/%s/", opts.Quality)
+	}
+
+	if opts.CutStart != "" && opts.CutLength != "" {
+		fmt.Fprintf(&b, "-/cut/%s/%s/", opts.CutStart, opts.CutLength)
+	}
+
+	if opts.Thumbs > 0 {
+		fmt.Fprintf(&b, "-/thumbs~%d/", opts.Thumbs)
+	}
+
+	return b.String()
+}

--- a/conversion/path.go
+++ b/conversion/path.go
@@ -7,16 +7,22 @@ import (
 
 type DocumentPathOptions struct {
 	UUID string
-	// Format is the target document format. Defaults to "pdf" when empty.
+	// Target document format. When empty, defaults to "png" if Page > 0
+	// (the backend only accepts /page/ for image formats) and "pdf" otherwise.
 	Format string
-	// Page extracts a single page when greater than zero.
+	// Page extracts a single page when greater than zero. Requires Format
+	// to be an image format (jpg, png, tiff, webp, enhanced.jpg).
 	Page int
 }
 
 func BuildDocumentPath(opts DocumentPathOptions) string {
 	format := opts.Format
 	if format == "" {
-		format = "pdf"
+		if opts.Page > 0 {
+			format = "png"
+		} else {
+			format = "pdf"
+		}
 	}
 
 	var b strings.Builder
@@ -30,7 +36,8 @@ func BuildDocumentPath(opts DocumentPathOptions) string {
 }
 
 type VideoPathOptions struct {
-	UUID   string
+	UUID string
+	// Target video format. Defaults to "mp4".
 	Format string
 	// Output dimensions, for example "640x480".
 	Size       string
@@ -43,8 +50,13 @@ type VideoPathOptions struct {
 }
 
 func BuildVideoPath(opts VideoPathOptions) string {
+	format := opts.Format
+	if format == "" {
+		format = "mp4"
+	}
+
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s/video/-/format/%s/", opts.UUID, opts.Format)
+	fmt.Fprintf(&b, "%s/video/-/format/%s/", opts.UUID, format)
 
 	if opts.Size != "" {
 		fmt.Fprintf(&b, "-/size/%s/", opts.Size)

--- a/conversion/path.go
+++ b/conversion/path.go
@@ -5,9 +5,7 @@ import (
 	"strings"
 )
 
-// DocumentPathOptions holds options for building a document conversion path.
 type DocumentPathOptions struct {
-	// UUID is the source file UUID.
 	UUID string
 	// Format is the target document format. Defaults to "pdf" when empty.
 	Format string
@@ -15,7 +13,6 @@ type DocumentPathOptions struct {
 	Page int
 }
 
-// BuildDocumentPath constructs a document conversion path.
 func BuildDocumentPath(opts DocumentPathOptions) string {
 	format := opts.Format
 	if format == "" {
@@ -32,27 +29,19 @@ func BuildDocumentPath(opts DocumentPathOptions) string {
 	return b.String()
 }
 
-// VideoPathOptions holds options for building a video conversion path.
 type VideoPathOptions struct {
-	// UUID is the source file UUID.
-	UUID string
-	// Format is the target video format.
+	UUID   string
 	Format string
-	// Size is the output dimensions, for example "640x480".
-	Size string
-	// ResizeMode controls how the video is resized.
+	// Output dimensions, for example "640x480".
+	Size       string
 	ResizeMode string
-	// Quality controls output quality.
-	Quality string
-	// CutStart is the start time for cutting.
-	CutStart string
-	// CutLength is the duration to cut.
-	CutLength string
-	// Thumbs is the number of thumbnails to generate.
+	Quality    string
+	CutStart   string
+	CutLength  string
+	// Number of thumbnails to generate.
 	Thumbs int
 }
 
-// BuildVideoPath constructs a video conversion path.
 func BuildVideoPath(opts VideoPathOptions) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s/video/-/format/%s/", opts.UUID, opts.Format)

--- a/conversion/path_test.go
+++ b/conversion/path_test.go
@@ -25,6 +25,11 @@ func TestBuildDocumentPath(t *testing.T) {
 			want: "abc-123/document/-/format/pdf/",
 		},
 		{
+			name: "default_format_with_page",
+			opts: DocumentPathOptions{UUID: "abc-123", Page: 1},
+			want: "abc-123/document/-/format/png/-/page/1/",
+		},
+		{
 			name: "with_page",
 			opts: DocumentPathOptions{UUID: "abc-123", Format: "png", Page: 3},
 			want: "abc-123/document/-/format/png/-/page/3/",
@@ -50,6 +55,11 @@ func TestBuildVideoPath(t *testing.T) {
 		{
 			name: "basic",
 			opts: VideoPathOptions{UUID: "abc-123", Format: "mp4"},
+			want: "abc-123/video/-/format/mp4/",
+		},
+		{
+			name: "default_format",
+			opts: VideoPathOptions{UUID: "abc-123"},
 			want: "abc-123/video/-/format/mp4/",
 		},
 		{

--- a/conversion/path_test.go
+++ b/conversion/path_test.go
@@ -1,0 +1,51 @@
+package conversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDocumentPath_FormatOnly(t *testing.T) {
+	t.Parallel()
+
+	path := BuildDocumentPath(DocumentPathOptions{UUID: "abc-123", Format: "pdf"})
+	assert.Equal(t, "abc-123/document/-/format/pdf/", path)
+}
+
+func TestBuildDocumentPath_DefaultFormat(t *testing.T) {
+	t.Parallel()
+
+	path := BuildDocumentPath(DocumentPathOptions{UUID: "abc-123"})
+	assert.Equal(t, "abc-123/document/-/format/pdf/", path)
+}
+
+func TestBuildDocumentPath_WithPage(t *testing.T) {
+	t.Parallel()
+
+	path := BuildDocumentPath(DocumentPathOptions{UUID: "abc-123", Format: "png", Page: 3})
+	assert.Equal(t, "abc-123/document/-/format/png/-/page/3/", path)
+}
+
+func TestBuildVideoPath_Basic(t *testing.T) {
+	t.Parallel()
+
+	path := BuildVideoPath(VideoPathOptions{UUID: "abc-123", Format: "mp4"})
+	assert.Equal(t, "abc-123/video/-/format/mp4/", path)
+}
+
+func TestBuildVideoPath_Full(t *testing.T) {
+	t.Parallel()
+
+	path := BuildVideoPath(VideoPathOptions{
+		UUID:       "abc-123",
+		Format:     "webm",
+		Size:       "640x480",
+		ResizeMode: "preserve_ratio",
+		Quality:    "best",
+		CutStart:   "000:00:05.000",
+		CutLength:  "000:00:15.000",
+		Thumbs:     10,
+	})
+	assert.Equal(t, "abc-123/video/-/format/webm/-/size/640x480/preserve_ratio/-/quality/best/-/cut/000:00:05.000/000:00:15.000/-/thumbs~10/", path)
+}

--- a/conversion/path_test.go
+++ b/conversion/path_test.go
@@ -6,46 +6,72 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuildDocumentPath_FormatOnly(t *testing.T) {
+func TestBuildDocumentPath(t *testing.T) {
 	t.Parallel()
 
-	path := BuildDocumentPath(DocumentPathOptions{UUID: "abc-123", Format: "pdf"})
-	assert.Equal(t, "abc-123/document/-/format/pdf/", path)
+	tests := []struct {
+		name string
+		opts DocumentPathOptions
+		want string
+	}{
+		{
+			name: "format_only",
+			opts: DocumentPathOptions{UUID: "abc-123", Format: "pdf"},
+			want: "abc-123/document/-/format/pdf/",
+		},
+		{
+			name: "default_format",
+			opts: DocumentPathOptions{UUID: "abc-123"},
+			want: "abc-123/document/-/format/pdf/",
+		},
+		{
+			name: "with_page",
+			opts: DocumentPathOptions{UUID: "abc-123", Format: "png", Page: 3},
+			want: "abc-123/document/-/format/png/-/page/3/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, BuildDocumentPath(tt.opts))
+		})
+	}
 }
 
-func TestBuildDocumentPath_DefaultFormat(t *testing.T) {
+func TestBuildVideoPath(t *testing.T) {
 	t.Parallel()
 
-	path := BuildDocumentPath(DocumentPathOptions{UUID: "abc-123"})
-	assert.Equal(t, "abc-123/document/-/format/pdf/", path)
-}
+	tests := []struct {
+		name string
+		opts VideoPathOptions
+		want string
+	}{
+		{
+			name: "basic",
+			opts: VideoPathOptions{UUID: "abc-123", Format: "mp4"},
+			want: "abc-123/video/-/format/mp4/",
+		},
+		{
+			name: "full",
+			opts: VideoPathOptions{
+				UUID:       "abc-123",
+				Format:     "webm",
+				Size:       "640x480",
+				ResizeMode: "preserve_ratio",
+				Quality:    "best",
+				CutStart:   "000:00:05.000",
+				CutLength:  "000:00:15.000",
+				Thumbs:     10,
+			},
+			want: "abc-123/video/-/format/webm/-/size/640x480/preserve_ratio/-/quality/best/-/cut/000:00:05.000/000:00:15.000/-/thumbs~10/",
+		},
+	}
 
-func TestBuildDocumentPath_WithPage(t *testing.T) {
-	t.Parallel()
-
-	path := BuildDocumentPath(DocumentPathOptions{UUID: "abc-123", Format: "png", Page: 3})
-	assert.Equal(t, "abc-123/document/-/format/png/-/page/3/", path)
-}
-
-func TestBuildVideoPath_Basic(t *testing.T) {
-	t.Parallel()
-
-	path := BuildVideoPath(VideoPathOptions{UUID: "abc-123", Format: "mp4"})
-	assert.Equal(t, "abc-123/video/-/format/mp4/", path)
-}
-
-func TestBuildVideoPath_Full(t *testing.T) {
-	t.Parallel()
-
-	path := BuildVideoPath(VideoPathOptions{
-		UUID:       "abc-123",
-		Format:     "webm",
-		Size:       "640x480",
-		ResizeMode: "preserve_ratio",
-		Quality:    "best",
-		CutStart:   "000:00:05.000",
-		CutLength:  "000:00:15.000",
-		Thumbs:     10,
-	})
-	assert.Equal(t, "abc-123/video/-/format/webm/-/size/640x480/preserve_ratio/-/quality/best/-/cut/000:00:05.000/000:00:15.000/-/thumbs~10/", path)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, BuildVideoPath(tt.opts))
+		})
+	}
 }

--- a/file/file.go
+++ b/file/file.go
@@ -11,14 +11,10 @@ import (
 	"github.com/uploadcare/uploadcare-go/v2/ucare"
 )
 
-// InfoParams holds optional parameters for the Info method.
 type InfoParams struct {
-	// Include specifies additional fields to include in the response.
-	// Valid value: "appdata".
 	Include *string `form:"include"`
 }
 
-// EncodeReq implements ucare.ReqEncoder.
 func (d *InfoParams) EncodeReq(req *http.Request) error {
 	return codec.EncodeReqQuery(d, req)
 }

--- a/file/file.go
+++ b/file/file.go
@@ -6,19 +6,39 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/uploadcare/uploadcare-go/v2/internal/codec"
 	"github.com/uploadcare/uploadcare-go/v2/internal/config"
+	"github.com/uploadcare/uploadcare-go/v2/ucare"
 )
+
+// InfoParams holds optional parameters for the Info method.
+type InfoParams struct {
+	// Include specifies additional fields to include in the response.
+	// Valid value: "appdata".
+	Include *string `form:"include"`
+}
+
+// EncodeReq implements ucare.ReqEncoder.
+func (d *InfoParams) EncodeReq(req *http.Request) error {
+	return codec.EncodeReqQuery(d, req)
+}
 
 // Info acquires some file-specific info
 func (s service) Info(
 	ctx context.Context,
 	fileID string,
+	params *InfoParams,
 ) (data Info, err error) {
+	var reqParams ucare.ReqEncoder
+	if params != nil {
+		reqParams = params
+	}
+
 	err = s.svc.ResourceOp(
 		ctx,
 		http.MethodGet,
 		fmt.Sprintf(infoPathFormat, fileID),
-		nil,
+		reqParams,
 		&data,
 	)
 	return
@@ -222,15 +242,15 @@ type Location struct {
 
 // ContentInfo holds information about file content
 type ContentInfo struct {
-	Mime *Mime `json:"mime"`
+	Mime  *Mime      `json:"mime"`
 	Video *VideoInfo `json:"video"`
 	Image *ImageInfo `json:"image"`
 }
 
 // Mime holds detected and parsed mime type
 type Mime struct {
-	Mime string `json:"mime"`
-	Type string `json:"type"`
+	Mime    string `json:"mime"`
+	Type    string `json:"type"`
 	Subtype string `json:"subtype"`
 }
 

--- a/file/list.go
+++ b/file/list.go
@@ -31,6 +31,10 @@ type ListParams struct {
 	// StartingFrom specifies a starting point for filtering files.
 	// The value depends on your ordering parameter value.
 	StartingFrom *time.Time `form:"from"`
+
+	// Include specifies additional fields to include in the response.
+	// Valid value: "appdata".
+	Include *string `form:"include"`
 }
 
 // EncodeReq implements ucare.ReqEncoder
@@ -65,6 +69,7 @@ func (v *List) ReadResult() (*Info, error) {
 // List returns a list of files.
 //
 // Example usage:
+//
 //	fileList, err := fileSvc.List(ctx, params)
 //	if err != nil {
 //		// handle error

--- a/file/service.go
+++ b/file/service.go
@@ -18,7 +18,7 @@ import (
 // Service describes all file related API
 type Service interface {
 	List(context.Context, ListParams) (*List, error)
-	Info(ctx context.Context, id string) (Info, error)
+	Info(ctx context.Context, id string, params *InfoParams) (Info, error)
 	Store(ctx context.Context, id string) (Info, error)
 	Delete(ctx context.Context, id string) (Info, error)
 	BatchStore(ctx context.Context, ids []string) (BatchInfo, error)

--- a/file/service_test.go
+++ b/file/service_test.go
@@ -1,0 +1,118 @@
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uploadcare/uploadcare-go/v2/internal/config"
+	"github.com/uploadcare/uploadcare-go/v2/ucare"
+)
+
+type testClient struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func (c *testClient) NewRequest(
+	ctx context.Context,
+	_ config.Endpoint,
+	method, requrl string,
+	data ucare.ReqEncoder,
+) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+requrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	if data != nil {
+		if err = data.EncodeReq(req); err != nil {
+			return nil, err
+		}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/vnd.uploadcare-v0.7+json")
+	return req, nil
+}
+
+func (c *testClient) Do(req *http.Request, resdata interface{}) error {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	if resdata == nil || reflect.ValueOf(resdata).IsNil() {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(resdata)
+}
+
+func newTestService(handler http.Handler) (Service, *httptest.Server) {
+	srv := httptest.NewServer(handler)
+	client := &testClient{httpClient: srv.Client(), baseURL: srv.URL}
+	return NewService(client), srv
+}
+
+func TestInfo_WithIncludeAppdata(t *testing.T) {
+	t.Parallel()
+
+	svc, srv := newTestService(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/files/test-uuid/", r.URL.Path)
+		assert.Equal(t, "appdata", r.URL.Query().Get("include"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Info{
+			BasicFileInfo: BasicFileInfo{ID: "test-uuid"},
+		})
+	}))
+	defer srv.Close()
+
+	info, err := svc.Info(context.Background(), "test-uuid", &InfoParams{
+		Include: ucare.String("appdata"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "test-uuid", info.ID)
+}
+
+func TestInfo_NilParams(t *testing.T) {
+	t.Parallel()
+
+	svc, srv := newTestService(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/files/test-uuid/", r.URL.Path)
+		assert.Empty(t, r.URL.RawQuery)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Info{
+			BasicFileInfo: BasicFileInfo{ID: "test-uuid"},
+		})
+	}))
+	defer srv.Close()
+
+	info, err := svc.Info(context.Background(), "test-uuid", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-uuid", info.ID)
+}
+
+func TestListParams_WithInclude(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.test/files/", nil)
+	assert.NoError(t, err)
+
+	err = (&ListParams{Include: ucare.String("appdata")}).EncodeReq(req)
+	assert.NoError(t, err)
+	assert.Equal(t, "appdata", req.URL.Query().Get("include"))
+}

--- a/file/service_test.go
+++ b/file/service_test.go
@@ -2,117 +2,56 @@ package file
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uploadcare/uploadcare-go/v2/internal/config"
+	"github.com/stretchr/testify/require"
+	"github.com/uploadcare/uploadcare-go/v2/internal/uctest"
 	"github.com/uploadcare/uploadcare-go/v2/ucare"
 )
 
-type testClient struct {
-	httpClient *http.Client
-	baseURL    string
-}
+const testFileUUID = "test-uuid"
 
-func (c *testClient) NewRequest(
-	ctx context.Context,
-	_ config.Endpoint,
-	method, requrl string,
-	data ucare.ReqEncoder,
-) (*http.Request, error) {
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+requrl, nil)
-	if err != nil {
-		return nil, err
-	}
-	if data != nil {
-		if err = data.EncodeReq(req); err != nil {
-			return nil, err
-		}
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/vnd.uploadcare-v0.7+json")
-	return req, nil
-}
-
-func (c *testClient) Do(req *http.Request, resdata interface{}) error {
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
-	}
-
-	if resdata == nil || reflect.ValueOf(resdata).IsNil() {
-		return nil
-	}
-	return json.NewDecoder(resp.Body).Decode(resdata)
-}
-
-func newTestService(handler http.Handler) (Service, *httptest.Server) {
-	srv := httptest.NewServer(handler)
-	client := &testClient{httpClient: srv.Client(), baseURL: srv.URL}
-	return NewService(client), srv
-}
-
-func TestInfo_WithIncludeAppdata(t *testing.T) {
+func TestInfo(t *testing.T) {
 	t.Parallel()
 
-	svc, srv := newTestService(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/files/test-uuid/", r.URL.Path)
-		assert.Equal(t, "appdata", r.URL.Query().Get("include"))
+	tests := []struct {
+		name      string
+		params    *InfoParams
+		wantQuery string
+	}{
+		{"nil_params", nil, ""},
+		{"include_appdata", &InfoParams{Include: ucare.String("appdata")}, "appdata"},
+	}
 
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(Info{
-			BasicFileInfo: BasicFileInfo{ID: "test-uuid"},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/files/"+testFileUUID+"/", r.URL.Path)
+				assert.Equal(t, tt.wantQuery, r.URL.Query().Get("include"))
+
+				uctest.RespondJSON(t, w, Info{BasicFileInfo: BasicFileInfo{ID: testFileUUID}})
+			}), func(t *testing.T, srv *httptest.Server) {
+				svc := NewService(uctest.NewServerClient(srv))
+				info, err := svc.Info(context.Background(), testFileUUID, tt.params)
+				require.NoError(t, err)
+				assert.Equal(t, testFileUUID, info.ID)
+			})
 		})
-	}))
-	defer srv.Close()
-
-	info, err := svc.Info(context.Background(), "test-uuid", &InfoParams{
-		Include: ucare.String("appdata"),
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "test-uuid", info.ID)
+	}
 }
 
-func TestInfo_NilParams(t *testing.T) {
-	t.Parallel()
-
-	svc, srv := newTestService(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/files/test-uuid/", r.URL.Path)
-		assert.Empty(t, r.URL.RawQuery)
-
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(Info{
-			BasicFileInfo: BasicFileInfo{ID: "test-uuid"},
-		})
-	}))
-	defer srv.Close()
-
-	info, err := svc.Info(context.Background(), "test-uuid", nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "test-uuid", info.ID)
-}
-
-func TestListParams_WithInclude(t *testing.T) {
+func TestListParams_Include(t *testing.T) {
 	t.Parallel()
 
 	req, err := http.NewRequest(http.MethodGet, "https://example.test/files/", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	err = (&ListParams{Include: ucare.String("appdata")}).EncodeReq(req)
-	assert.NoError(t, err)
+	require.NoError(t, (&ListParams{Include: ucare.String("appdata")}).EncodeReq(req))
 	assert.Equal(t, "appdata", req.URL.Query().Get("include"))
 }

--- a/file/service_test.go
+++ b/file/service_test.go
@@ -45,7 +45,7 @@ func (c *testClient) Do(req *http.Request, resdata interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)
@@ -73,7 +73,7 @@ func TestInfo_WithIncludeAppdata(t *testing.T) {
 		assert.Equal(t, "appdata", r.URL.Query().Get("include"))
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(Info{
+		_ = json.NewEncoder(w).Encode(Info{
 			BasicFileInfo: BasicFileInfo{ID: "test-uuid"},
 		})
 	}))
@@ -95,7 +95,7 @@ func TestInfo_NilParams(t *testing.T) {
 		assert.Empty(t, r.URL.RawQuery)
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(Info{
+		_ = json.NewEncoder(w).Encode(Info{
 			BasicFileInfo: BasicFileInfo{ID: "test-uuid"},
 		})
 	}))

--- a/internal/codec/codec.go
+++ b/internal/codec/codec.go
@@ -111,12 +111,33 @@ func EncodeReqQuery(data interface{}, req *http.Request) error {
 
 	q := req.URL.Query()
 	for i := 0; i < t.NumField(); i++ {
-		f := v.Field(i)
+		tf, f := t.Field(i), v.Field(i)
+		formKey := tf.Tag.Get("form")
+		if formKey == "" {
+			continue
+		}
+
 		if f.Kind() == reflect.Ptr && f.IsNil() {
 			continue
 		}
 
-		q.Set(t.Field(i).Tag.Get("form"), fieldValue(f))
+		if f.Kind() == reflect.Map {
+			if f.IsNil() {
+				continue
+			}
+
+			m, ok := f.Interface().(map[string]string)
+			if !ok {
+				panic(wrongMapType)
+			}
+
+			for k, v := range m {
+				q.Set(fmt.Sprintf("%s[%s]", formKey, k), v)
+			}
+			continue
+		}
+
+		q.Set(formKey, fieldValue(f))
 	}
 	req.URL.RawQuery = q.Encode()
 	return nil
@@ -263,18 +284,28 @@ func writeFormField(
 		return
 	}
 
+	formKey := t.Tag.Get("form")
+
 	if f.Kind() == reflect.Map {
+		if f.IsNil() {
+			return
+		}
+
 		m, ok := f.Interface().(map[string]string)
 		if !ok {
 			panic(wrongMapType)
 		}
+
 		for k, v := range m {
-			_ = w.WriteField(k, v)
+			fieldName := k
+			if formKey != "" {
+				fieldName = fmt.Sprintf("%s[%s]", formKey, k)
+			}
+			_ = w.WriteField(fieldName, v)
 		}
 		return
 	}
 
-	formKey := t.Tag.Get("form")
 	if formKey == "" {
 		return
 	}

--- a/internal/codec/codec_test.go
+++ b/internal/codec/codec_test.go
@@ -28,6 +28,7 @@ func TestEncodeReqQuery(t *testing.T) {
 
 		params        interface{}
 		expectedQuery url.Values
+		wantErr       bool
 	}{{
 		test: "full list of params",
 		params: &file.ListParams{
@@ -43,6 +44,14 @@ func TestEncodeReqQuery(t *testing.T) {
 			"limit":    []string{"500"},
 			"ordering": []string{"datetime_uploaded"},
 			"from":     []string{"2015-01-02T10:00:00"},
+		},
+	}, {
+		test: "include appdata",
+		params: &file.ListParams{
+			Include: ucare.String("appdata"),
+		},
+		expectedQuery: url.Values{
+			"include": []string{"appdata"},
 		},
 	}, {
 		test:          "empty list",
@@ -64,20 +73,28 @@ func TestEncodeReqQuery(t *testing.T) {
 			"stored": ucare.Bool(false),
 		},
 		expectedQuery: url.Values{},
+		wantErr:       true,
 	}, {
 		test: "not struct pointer params type",
 		params: &map[string]*bool{
 			"stored": ucare.Bool(false),
 		},
 		expectedQuery: url.Values{},
+		wantErr:       true,
 	}}
 
 	for _, c := range cases {
 		t.Run(c.test, func(t *testing.T) {
 			t.Parallel()
 
-			req, _ := http.NewRequest("GET", "", nil)
-			_ = codec.EncodeReqQuery(c.params, req)
+			req, _ := http.NewRequest(http.MethodGet, "https://example.test", nil)
+			err := codec.EncodeReqQuery(c.params, req)
+			if c.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
 			q := req.URL.Query()
 
 			if len(c.expectedQuery) == 0 && req.URL.RawQuery != "" {
@@ -108,8 +125,9 @@ func TestEncodeReqBody(t *testing.T) {
 		t.Run(c.test, func(t *testing.T) {
 			t.Parallel()
 
-			req, _ := http.NewRequest("PUT", "", nil)
-			_ = codec.EncodeReqBody(c.params, req)
+			req, _ := http.NewRequest(http.MethodPut, "https://example.test", nil)
+			err := codec.EncodeReqBody(c.params, req)
+			assert.NoError(t, err)
 
 			data, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
@@ -200,4 +218,74 @@ func TestEncodeReqFormData(t *testing.T) {
 			require.NoError(t, c.testReq(string(data)))
 		})
 	}
+}
+
+func TestEncodeReqFormData_WithMetadata(t *testing.T) {
+	t.Parallel()
+
+	body, _, err := codec.EncodeReqFormData(&struct {
+		Metadata map[string]string `form:"metadata"`
+	}{
+		Metadata: map[string]string{
+			"key1": "val1",
+			"key2": "val2",
+		},
+	})
+	assert.NoError(t, err)
+
+	data, err := io.ReadAll(body)
+	assert.NoError(t, err)
+
+	written := string(data)
+	assert.Contains(t, written, `name="metadata[key1]"`)
+	assert.Contains(t, written, "val1")
+	assert.Contains(t, written, `name="metadata[key2]"`)
+	assert.Contains(t, written, "val2")
+}
+
+func TestEncodeReqFormData_NilMetadata(t *testing.T) {
+	t.Parallel()
+
+	body, _, err := codec.EncodeReqFormData(&struct {
+		Metadata map[string]string `form:"metadata"`
+	}{})
+	assert.NoError(t, err)
+
+	data, err := io.ReadAll(body)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "metadata[")
+}
+
+func TestEncodeReqFormData_EmptyMetadata(t *testing.T) {
+	t.Parallel()
+
+	body, _, err := codec.EncodeReqFormData(&struct {
+		Metadata map[string]string `form:"metadata"`
+	}{
+		Metadata: map[string]string{},
+	})
+	assert.NoError(t, err)
+
+	data, err := io.ReadAll(body)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "metadata[")
+}
+
+func TestEncodeReqQuery_WithMetadata(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.test", nil)
+	err := codec.EncodeReqQuery(&struct {
+		Metadata map[string]string `form:"metadata"`
+	}{
+		Metadata: map[string]string{
+			"key1": "val1",
+			"key2": "val2",
+		},
+	}, req)
+	assert.NoError(t, err)
+
+	q := req.URL.Query()
+	assert.Equal(t, "val1", q.Get("metadata[key1]"))
+	assert.Equal(t, "val2", q.Get("metadata[key2]"))
 }

--- a/internal/codec/codec_test.go
+++ b/internal/codec/codec_test.go
@@ -54,6 +54,17 @@ func TestEncodeReqQuery(t *testing.T) {
 			"include": []string{"appdata"},
 		},
 	}, {
+		test: "metadata bracket keys",
+		params: &struct {
+			Metadata map[string]string `form:"metadata"`
+		}{
+			Metadata: map[string]string{"key1": "val1", "key2": "val2"},
+		},
+		expectedQuery: url.Values{
+			"metadata[key1]": []string{"val1"},
+			"metadata[key2]": []string{"val2"},
+		},
+	}, {
 		test:          "empty list",
 		params:        &file.ListParams{},
 		expectedQuery: url.Values{},
@@ -126,8 +137,7 @@ func TestEncodeReqBody(t *testing.T) {
 			t.Parallel()
 
 			req, _ := http.NewRequest(http.MethodPut, "https://example.test", nil)
-			err := codec.EncodeReqBody(c.params, req)
-			assert.NoError(t, err)
+			require.NoError(t, codec.EncodeReqBody(c.params, req))
 
 			data, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
@@ -200,6 +210,46 @@ func TestEncodeReqFormData(t *testing.T) {
 			}
 			return nil
 		},
+	}, {
+		test: "metadata bracket keys",
+		data: &struct {
+			Metadata map[string]string `form:"metadata"`
+		}{
+			Metadata: map[string]string{"key1": "val1", "key2": "val2"},
+		},
+		testReq: func(written string) error {
+			if !strings.Contains(written, `name="metadata[key1]"`) ||
+				!strings.Contains(written, "val1") ||
+				!strings.Contains(written, `name="metadata[key2]"`) ||
+				!strings.Contains(written, "val2") {
+				return errors.New("metadata bracket keys not written")
+			}
+			return nil
+		},
+	}, {
+		test: "nil metadata omitted",
+		data: &struct {
+			Metadata map[string]string `form:"metadata"`
+		}{},
+		testReq: func(written string) error {
+			if strings.Contains(written, "metadata[") {
+				return errors.New("nil metadata should not be written")
+			}
+			return nil
+		},
+	}, {
+		test: "empty metadata omitted",
+		data: &struct {
+			Metadata map[string]string `form:"metadata"`
+		}{
+			Metadata: map[string]string{},
+		},
+		testReq: func(written string) error {
+			if strings.Contains(written, "metadata[") {
+				return errors.New("empty metadata should not be written")
+			}
+			return nil
+		},
 	}}
 
 	for _, c := range cases {
@@ -218,74 +268,4 @@ func TestEncodeReqFormData(t *testing.T) {
 			require.NoError(t, c.testReq(string(data)))
 		})
 	}
-}
-
-func TestEncodeReqFormData_WithMetadata(t *testing.T) {
-	t.Parallel()
-
-	body, _, err := codec.EncodeReqFormData(&struct {
-		Metadata map[string]string `form:"metadata"`
-	}{
-		Metadata: map[string]string{
-			"key1": "val1",
-			"key2": "val2",
-		},
-	})
-	assert.NoError(t, err)
-
-	data, err := io.ReadAll(body)
-	assert.NoError(t, err)
-
-	written := string(data)
-	assert.Contains(t, written, `name="metadata[key1]"`)
-	assert.Contains(t, written, "val1")
-	assert.Contains(t, written, `name="metadata[key2]"`)
-	assert.Contains(t, written, "val2")
-}
-
-func TestEncodeReqFormData_NilMetadata(t *testing.T) {
-	t.Parallel()
-
-	body, _, err := codec.EncodeReqFormData(&struct {
-		Metadata map[string]string `form:"metadata"`
-	}{})
-	assert.NoError(t, err)
-
-	data, err := io.ReadAll(body)
-	assert.NoError(t, err)
-	assert.NotContains(t, string(data), "metadata[")
-}
-
-func TestEncodeReqFormData_EmptyMetadata(t *testing.T) {
-	t.Parallel()
-
-	body, _, err := codec.EncodeReqFormData(&struct {
-		Metadata map[string]string `form:"metadata"`
-	}{
-		Metadata: map[string]string{},
-	})
-	assert.NoError(t, err)
-
-	data, err := io.ReadAll(body)
-	assert.NoError(t, err)
-	assert.NotContains(t, string(data), "metadata[")
-}
-
-func TestEncodeReqQuery_WithMetadata(t *testing.T) {
-	t.Parallel()
-
-	req, _ := http.NewRequest(http.MethodGet, "https://example.test", nil)
-	err := codec.EncodeReqQuery(&struct {
-		Metadata map[string]string `form:"metadata"`
-	}{
-		Metadata: map[string]string{
-			"key1": "val1",
-			"key2": "val2",
-		},
-	}, req)
-	assert.NoError(t, err)
-
-	q := req.URL.Query()
-	assert.Equal(t, "val1", q.Get("metadata[key1]"))
-	assert.Equal(t, "val2", q.Get("metadata[key2]"))
 }

--- a/test/file.go
+++ b/test/file.go
@@ -27,7 +27,7 @@ func listFiles(t *testing.T, r *testenv.Runner) {
 
 func fileInfo(t *testing.T, r *testenv.Runner) {
 	ctx := context.Background()
-	info, err := r.File.Info(ctx, r.Artifacts.Files[0].ID)
+	info, err := r.File.Info(ctx, r.Artifacts.Files[0].ID, nil)
 	assert.Equal(t, nil, err)
 	assert.Equal(
 		t,

--- a/test/webhook.go
+++ b/test/webhook.go
@@ -66,6 +66,6 @@ func webhookList(t *testing.T, r *testenv.Runner) {
 }
 
 func webhookDelete(t *testing.T, r *testenv.Runner) {
-	err := r.Webhook.Delete(context.Background(), webhookURL)
+	err := r.Webhook.Delete(context.Background(), r.Artifacts.Webhook.ID)
 	assert.Equal(t, nil, err)
 }

--- a/ucare/doc.go
+++ b/ucare/doc.go
@@ -55,7 +55,7 @@ Getting a list of files:
 Acquiring file-specific info:
 
 	fileID := ids[0]
-	file, err := fileSvc.Info(context.Background(), fileID)
+	file, err := fileSvc.Info(context.Background(), fileID, nil)
 	if err != nil {
 		// handle error
 	}
@@ -133,6 +133,5 @@ Uploading a file
 	if err != nil {
 		// handle error
 	}
-
 */
 package ucare

--- a/upload/direct.go
+++ b/upload/direct.go
@@ -35,6 +35,9 @@ type FileParams struct {
 	//	upload.ToStoreFalse
 	//	upload.ToStoreAuto
 	ToStore *string `form:"UPLOADCARE_STORE"`
+
+	// Metadata stores user-defined key-value pairs with the uploaded file.
+	Metadata map[string]string `form:"metadata"`
 }
 
 type uploadFileAuthParams struct {

--- a/upload/fromurl.go
+++ b/upload/fromurl.go
@@ -44,6 +44,9 @@ type FromURLParams struct {
 	//	upload.URLDuplicatesTrue
 	//	upload.URLDuplicatesFalse
 	SaveURLDuplicates *string `form:"save_URL_duplicates"`
+
+	// Metadata stores user-defined key-value pairs with the uploaded file.
+	Metadata map[string]string `form:"metadata"`
 }
 
 type fromURLAuthParams struct {
@@ -185,6 +188,7 @@ func (d *fromURLData) Info() (FileInfo, bool) {
 
 // Done is used to wait for uploading to be done. If uploading fails it will
 // never receive FileInfo value:
+//
 //	select {
 //	case fileinfo := <-res.Done():
 //		// file info received

--- a/upload/multipart.go
+++ b/upload/multipart.go
@@ -34,6 +34,9 @@ type MultipartParams struct {
 	//	upload.ToStoreFalse
 	//	upload.ToStoreAuto
 	ToStore *string `form:"UPLOADCARE_STORE"`
+
+	// Metadata stores user-defined key-value pairs with the uploaded file.
+	Metadata map[string]string `form:"metadata"`
 }
 
 type multipartAuthParams struct {
@@ -250,6 +253,7 @@ func (d partEncoder) EncodeReq(req *http.Request) error {
 
 // Done is used to wait for uploading to be done. If uploading fails it will
 // never receive FileInfo value:
+//
 //	select {
 //	case fileinfo := <-res.Done():
 //		// file info received

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -8,11 +8,23 @@ import (
 const DefaultMultipartThreshold int64 = 10 * 1024 * 1024 // 10MB
 
 type UploadParams struct {
-	Data               io.ReadSeeker
-	Name               string
-	ContentType        string
-	Size               int64
-	ToStore            *string
+	// Data (required) reads the data to be uploaded.
+	Data io.ReadSeeker
+	// Name (required) is the original filename.
+	Name string
+	// ContentType is the file MIME-type.
+	ContentType string
+	// Size (required) is the precise file size in bytes.
+	Size int64
+	// ToStore sets the file storing behaviour.
+	ToStore *string
+	// Metadata stores user-defined key-value pairs with the uploaded file.
+	Metadata map[string]string
+	// MultipartThreshold controls the upload method selection:
+	//   nil    → use DefaultMultipartThreshold (10MB)
+	//   > 0   → use as custom threshold
+	//   0     → force direct upload
+	//   < 0   → force multipart upload
 	MultipartThreshold *int64
 }
 
@@ -54,6 +66,7 @@ func (s service) uploadDirect(ctx context.Context, params UploadParams) (FileInf
 		Name:        params.Name,
 		ContentType: params.ContentType,
 		ToStore:     params.ToStore,
+		Metadata:    params.Metadata,
 	})
 	if err != nil {
 		return FileInfo{}, err
@@ -68,6 +81,7 @@ func (s service) uploadMultipart(ctx context.Context, params UploadParams) (File
 		ContentType: params.ContentType,
 		Size:        params.Size,
 		ToStore:     params.ToStore,
+		Metadata:    params.Metadata,
 	})
 	if err != nil {
 		return FileInfo{}, err

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -8,19 +8,13 @@ import (
 const DefaultMultipartThreshold int64 = 10 * 1024 * 1024 // 10MB
 
 type UploadParams struct {
-	// Data (required) reads the data to be uploaded.
-	Data io.ReadSeeker
-	// Name (required) is the original filename.
-	Name string
-	// ContentType is the file MIME-type.
+	Data        io.ReadSeeker
+	Name        string
 	ContentType string
-	// Size (required) is the precise file size in bytes.
-	Size int64
-	// ToStore sets the file storing behaviour.
-	ToStore *string
-	// Metadata stores user-defined key-value pairs with the uploaded file.
-	Metadata map[string]string
-	// MultipartThreshold controls the upload method selection:
+	Size        int64
+	ToStore     *string
+	Metadata    map[string]string
+	// Controls the upload method selection:
 	//   nil    → use DefaultMultipartThreshold (10MB)
 	//   > 0   → use as custom threshold
 	//   0     → force direct upload

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -3,10 +3,8 @@ package upload
 import (
 	"bytes"
 	"context"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -149,69 +147,54 @@ func TestUpload(t *testing.T) {
 	})
 }
 
-func TestUpload_MetadataPassThrough_DirectUpload(t *testing.T) {
+func TestUpload_Metadata(t *testing.T) {
 	t.Parallel()
 
-	uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/base/":
-			body, err := io.ReadAll(r.Body)
-			assert.NoError(t, err)
-			assert.Contains(t, string(body), `name="metadata[source]"`)
-			assert.Contains(t, string(body), "cli")
-			uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-metadata-direct"})
-		case "/info/":
-			uctest.RespondJSON(t, w, FileInfo{FileName: "meta.txt"})
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}), func(t *testing.T, srv *httptest.Server) {
-		svc := NewService(uctest.NewUploadServerClient(srv))
+	tests := []struct {
+		name         string
+		threshold    *int64
+		metadataPath string
+		fileName     string
+	}{
+		{"direct", int64Ptr(0), "/base/", "meta.txt"},
+		{"multipart", int64Ptr(-1), "/multipart/start/", "meta-multi.txt"},
+	}
 
-		info, err := svc.Upload(context.Background(), UploadParams{
-			Data:     strings.NewReader("hi"),
-			Name:     "meta.txt",
-			Size:     2,
-			Metadata: map[string]string{"source": "cli"},
-		})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		require.NoError(t, err)
-		assert.Equal(t, "meta.txt", info.FileName)
-	})
-}
+			uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case tt.metadataPath:
+					body := uctest.ReadBody(t, r)
+					assert.Contains(t, string(body), `name="metadata[source]"`)
+					assert.Contains(t, string(body), "cli")
+					if tt.metadataPath == "/multipart/start/" {
+						uctest.RespondJSON(t, w, map[string]any{"uuid": "test-uuid", "parts": []string{}})
+					} else {
+						uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid"})
+					}
+				case "/info/", "/multipart/complete/":
+					uctest.RespondJSON(t, w, FileInfo{FileName: tt.fileName})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}), func(t *testing.T, srv *httptest.Server) {
+				svc := NewService(uctest.NewUploadServerClient(srv))
 
-func TestUpload_MetadataPassThrough_MultipartUpload(t *testing.T) {
-	t.Parallel()
+				info, err := svc.Upload(context.Background(), UploadParams{
+					Data:               bytes.NewReader([]byte("hello")),
+					Name:               tt.fileName,
+					ContentType:        "text/plain",
+					Size:               5,
+					Metadata:           map[string]string{"source": "cli"},
+					MultipartThreshold: tt.threshold,
+				})
 
-	uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/multipart/start/":
-			body, err := io.ReadAll(r.Body)
-			assert.NoError(t, err)
-			assert.Contains(t, string(body), `name="metadata[source]"`)
-			assert.Contains(t, string(body), "cli")
-			uctest.RespondJSON(t, w, map[string]interface{}{
-				"uuid":  "test-uuid-metadata-multipart",
-				"parts": []string{},
+				require.NoError(t, err)
+				assert.Equal(t, tt.fileName, info.FileName)
 			})
-		case "/multipart/complete/":
-			uctest.RespondJSON(t, w, FileInfo{FileName: "meta-multi.txt"})
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}), func(t *testing.T, srv *httptest.Server) {
-		svc := NewService(uctest.NewUploadServerClient(srv))
-
-		info, err := svc.Upload(context.Background(), UploadParams{
-			Data:               bytes.NewReader([]byte("hello")),
-			Name:               "meta-multi.txt",
-			ContentType:        "text/plain",
-			Size:               5,
-			Metadata:           map[string]string{"source": "cli"},
-			MultipartThreshold: int64Ptr(-1),
 		})
-
-		require.NoError(t, err)
-		assert.Equal(t, "meta-multi.txt", info.FileName)
-	})
+	}
 }

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -3,8 +3,10 @@ package upload
 import (
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -144,5 +146,72 @@ func TestUpload(t *testing.T) {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "empty upload ID")
 		})
+	})
+}
+
+func TestUpload_MetadataPassThrough_DirectUpload(t *testing.T) {
+	t.Parallel()
+
+	uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/base/":
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.Contains(t, string(body), `name="metadata[source]"`)
+			assert.Contains(t, string(body), "cli")
+			uctest.RespondJSON(t, w, map[string]string{"file": "test-uuid-metadata-direct"})
+		case "/info/":
+			uctest.RespondJSON(t, w, FileInfo{FileName: "meta.txt"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}), func(t *testing.T, srv *httptest.Server) {
+		svc := NewService(uctest.NewUploadServerClient(srv))
+
+		info, err := svc.Upload(context.Background(), UploadParams{
+			Data:     strings.NewReader("hi"),
+			Name:     "meta.txt",
+			Size:     2,
+			Metadata: map[string]string{"source": "cli"},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "meta.txt", info.FileName)
+	})
+}
+
+func TestUpload_MetadataPassThrough_MultipartUpload(t *testing.T) {
+	t.Parallel()
+
+	uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/multipart/start/":
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.Contains(t, string(body), `name="metadata[source]"`)
+			assert.Contains(t, string(body), "cli")
+			uctest.RespondJSON(t, w, map[string]interface{}{
+				"uuid":  "test-uuid-metadata-multipart",
+				"parts": []string{},
+			})
+		case "/multipart/complete/":
+			uctest.RespondJSON(t, w, FileInfo{FileName: "meta-multi.txt"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}), func(t *testing.T, srv *httptest.Server) {
+		svc := NewService(uctest.NewUploadServerClient(srv))
+
+		info, err := svc.Upload(context.Background(), UploadParams{
+			Data:               bytes.NewReader([]byte("hello")),
+			Name:               "meta-multi.txt",
+			ContentType:        "text/plain",
+			Size:               5,
+			Metadata:           map[string]string{"source": "cli"},
+			MultipartThreshold: int64Ptr(-1),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "meta-multi.txt", info.FileName)
 	})
 }

--- a/webhook/service.go
+++ b/webhook/service.go
@@ -14,7 +14,7 @@ type Service interface {
 	List(context.Context) ([]Info, error)
 	Create(context.Context, Params) (Info, error)
 	Update(context.Context, Params) (Info, error)
-	Delete(ctx context.Context, targetURL string) error
+	Delete(ctx context.Context, id int64) error
 }
 
 type service struct {
@@ -25,7 +25,7 @@ const (
 	listPathFormat   = "/webhooks/"
 	createPathFormat = "/webhooks/"
 	updatePathFormat = "/webhooks/%d/"
-	deletePathFormat = "/webhooks/unsubscribe/"
+	deletePathFormat = "/webhooks/%d/"
 )
 
 type Event string

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -58,29 +58,19 @@ func (s service) Update(
 	return
 }
 
-// Unsubscribe and delete webhoo
+// Delete removes a webhook by ID.
 func (s service) Delete(
 	ctx context.Context,
-	targetURL string,
+	id int64,
 ) (err error) {
-	var params = deleteParams{targetURL}
-
 	err = s.svc.ResourceOp(
 		ctx,
 		http.MethodDelete,
-		deletePathFormat,
-		params,
+		fmt.Sprintf(deletePathFormat, id),
+		nil,
 		nil,
 	)
 	return
-}
-
-type deleteParams struct {
-	TargetURL string `json:"target_url"`
-}
-
-func (p deleteParams) EncodeReq(req *http.Request) error {
-	return codec.EncodeReqBody(p, req)
 }
 
 // Info holds webhook related information

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -10,7 +10,6 @@ import (
 	"github.com/uploadcare/uploadcare-go/v2/internal/config"
 )
 
-// List of project webhooks
 func (s service) List(
 	ctx context.Context,
 ) (data []Info, err error) {
@@ -24,7 +23,6 @@ func (s service) List(
 	return
 }
 
-// Create and subscribe to webhook
 func (s service) Create(
 	ctx context.Context,
 	params Params,
@@ -39,7 +37,6 @@ func (s service) Create(
 	return
 }
 
-// Update webhook attributes
 func (s service) Update(
 	ctx context.Context,
 	params Params,
@@ -58,7 +55,6 @@ func (s service) Update(
 	return
 }
 
-// Delete removes a webhook by ID.
 func (s service) Delete(
 	ctx context.Context,
 	id int64,
@@ -73,7 +69,6 @@ func (s service) Delete(
 	return
 }
 
-// Info holds webhook related information
 type Info struct {
 	// Webhook ID
 	ID int64 `json:"id"`

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -123,16 +123,13 @@ func TestDelete(t *testing.T) {
 
 	uctest.WithHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Equal(t, "/webhooks/unsubscribe/", r.URL.Path)
-
-		var body deleteParams
-		require.NoError(t, json.Unmarshal(uctest.ReadBody(t, r), &body))
-		assert.Equal(t, "https://example.com/hook", body.TargetURL)
+		assert.Equal(t, "/webhooks/123/", r.URL.Path)
+		assert.Empty(t, uctest.ReadBody(t, r))
 
 		w.WriteHeader(http.StatusNoContent)
 	}), func(t *testing.T, srv *httptest.Server) {
 		svc := NewService(uctest.NewServerClient(srv))
-		err := svc.Delete(context.Background(), "https://example.com/hook")
+		err := svc.Delete(context.Background(), 123)
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
- add Upload API metadata support and propagate it through unified upload helpers
- add file include params, conversion save_in_group support, and conversion path builder helpers
- change webhook delete to operate on webhook IDs and update docs/changelog/examples
- add unit coverage for codec encoding, file info/list params, conversion helpers, upload metadata, and webhook deletion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uploads can include metadata (direct, multipart, from-URL) using bracketed key/value encoding.
  * File info/list calls accept an optional include parameter to request extra fields (e.g., appdata).
  * New conversion helpers to build document/video paths and an option to save conversions into a group.

* **Bug Fixes**
  * Webhook deletion now uses webhook ID to remove entries reliably.

* **Tests**
  * Added tests for metadata encoding, conversion path builders, and file info/include behavior.

* **Documentation**
  * Examples updated to reflect the new file-info usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->