### PR TITLE
Fix missing User-Agent header in Upload API client

### DIFF
--- a/ucare/uploadapi.go
+++ b/ucare/uploadapi.go
@@ -10,7 +10,8 @@ import (
 )
 
 type uploadAPIClient struct {
-	authFunc UploadAPIAuthFunc
+	authFunc  UploadAPIAuthFunc
+	userAgent string
 
 	conn  *http.Client
 	retry *RetryConfig
@@ -25,6 +26,16 @@ func newUploadAPIClient(creds APICreds, conf *Config) Client {
 
 	if conf.SignBasedAuthentication {
 		c.authFunc = signBasedUploadAPIAuthFunc(creds)
+	}
+
+	c.userAgent = fmt.Sprintf(
+		"%s/%s/%s",
+		config.UserAgentPrefix,
+		config.ClientVersion,
+		creds.PublicKey,
+	)
+	if conf.UserAgent != "" {
+		c.userAgent += " " + conf.UserAgent
 	}
 
 	return &c
@@ -54,6 +65,8 @@ func (c *uploadAPIClient) NewRequest(
 			return nil, err
 		}
 	}
+
+	req.Header.Set(userAgentHeaderKey, c.userAgent)
 
 	log.Debugf(
 		"created new request: %s %+v %+v",

--- a/ucare/uploadapi_test.go
+++ b/ucare/uploadapi_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -18,43 +19,75 @@ import (
 func TestUploadAPIClient(t *testing.T) {
 	t.Parallel()
 
-	conf, err := NewConfig(testCreds())
-	require.NoError(t, err)
-	client := newUploadAPIClient(testCreds(), conf)
-
 	cases := []struct {
 		test string
 
-		endpoint config.Endpoint
-		method   string
-		requrl   string
-		data     ReqEncoder
+		configOpts []Option
+		endpoint   config.Endpoint
+		method     string
+		requrl     string
+		data       ReqEncoder
 
 		checkReq func(*http.Request) error
-	}{{
-		test:     "form_data",
-		endpoint: config.UploadAPIEndpoint,
-		method:   http.MethodPost,
-		requrl:   "/base/",
-		data: testReqEncoder{
-			body:  "formkey=formvalue",
-			query: "qparam1=qparamvalue1&qparam2=qparamvalue2",
+	}{
+		{
+			test:     "form_data",
+			endpoint: config.UploadAPIEndpoint,
+			method:   http.MethodPost,
+			requrl:   "/base/",
+			data: testReqEncoder{
+				body:  "formkey=formvalue",
+				query: "qparam1=qparamvalue1&qparam2=qparamvalue2",
+			},
+			checkReq: func(r *http.Request) error {
+				data, _ := io.ReadAll(r.Body)
+				if string(data) != "formkey=formvalue" {
+					return errors.New("invalid req body data")
+				}
+				if r.URL.RawQuery != "qparam1=qparamvalue1&qparam2=qparamvalue2" {
+					return errors.New("invalid req query")
+				}
+				return nil
+			},
 		},
-		checkReq: func(r *http.Request) error {
-			data, _ := io.ReadAll(r.Body)
-			if string(data) != "formkey=formvalue" {
-				return errors.New("invalid req body data")
-			}
-			if r.URL.RawQuery != "qparam1=qparamvalue1&qparam2=qparamvalue2" {
-				return errors.New("invalid req query")
-			}
-			return nil
+		{
+			test:     "user_agent",
+			endpoint: config.UploadAPIEndpoint,
+			method:   http.MethodPost,
+			requrl:   "/base/",
+			checkReq: func(r *http.Request) error {
+				if !strings.Contains(r.Header.Get("User-Agent"), config.UserAgentPrefix+"/") {
+					return errors.New("expected User-Agent to contain UploadcareGo/")
+				}
+				return nil
+			},
 		},
-	}}
+		{
+			test:       "custom_user_agent",
+			configOpts: []Option{WithUserAgent("MyApp/1.0")},
+			endpoint:   config.UploadAPIEndpoint,
+			method:     http.MethodPost,
+			requrl:     "/base/",
+			checkReq: func(r *http.Request) error {
+				userAgent := r.Header.Get("User-Agent")
+				if !strings.Contains(userAgent, config.UserAgentPrefix+"/") {
+					return errors.New("expected User-Agent to contain UploadcareGo/")
+				}
+				if !strings.Contains(userAgent, "MyApp/1.0") {
+					return errors.New("expected User-Agent to contain custom value")
+				}
+				return nil
+			},
+		},
+	}
 
 	for _, c := range cases {
 		t.Run(c.test, func(t *testing.T) {
 			t.Parallel()
+
+			conf, err := NewConfig(testCreds(), c.configOpts...)
+			require.NoError(t, err)
+			client := newUploadAPIClient(testCreds(), conf)
 
 			req, err := client.NewRequest(
 				context.Background(),


### PR DESCRIPTION
- Adds User-Agent construction to the Upload API client with format: `UploadcareGo/<version>/<public key>`.
- Appends custom `Config.UserAgent` values when provided via `WithUserAgent`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload API client now automatically includes a User-Agent header in HTTP requests, constructed from client version information, public key, and optional configuration parameters.

* **Tests**
  * Refactored test suite to use table-driven test cases for improved coverage and validation of User-Agent header behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uploadcare/uploadcare-go/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->