### PR TITLE
Add Project API moderation and meta support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ BREAKING CHANGES:
 
 FEATURES:
 
-* Add `projectapi` package for the Project API with bearer token authentication — manage projects, secret keys, and usage metrics
+* Add `projectapi` package for the Project API with bearer token authentication — manage projects, project features, moderation thresholds, meta reference lists, secret keys, and usage metrics
 * Add `ucare.NewBearerConfig()` and `ucare.NewBearerClient()` for bearer token authentication used by the Project API
 * Add `ucare.ProjectAPIError` type for Project API error responses
 * Add typed Project API usage metric constants for `traffic`, `storage`, and `operations`
+* Add Project API moderation threshold methods and meta reference methods for MIME types and moderation categories
 * Add `addon` package for Addons API execution and status polling
 * Add typed addon params for Remove.bg and ClamAV requests
 * Add `metadata` package with file metadata CRUD operations

--- a/projectapi/meta.go
+++ b/projectapi/meta.go
@@ -1,0 +1,33 @@
+package projectapi
+
+import (
+	"context"
+	"net/http"
+)
+
+const (
+	metaMimeTypesPath            = "/meta/mime/types/"
+	metaModerationCategoriesPath = "/meta/moderation/categories/"
+)
+
+func (s service) ListMimeTypes(ctx context.Context) (data MimeTypes, err error) {
+	err = s.svc.ResourceOp(
+		ctx,
+		http.MethodGet,
+		metaMimeTypesPath,
+		nil,
+		&data,
+	)
+	return
+}
+
+func (s service) ListModerationCategories(ctx context.Context) (data ModerationCategories, err error) {
+	err = s.svc.ResourceOp(
+		ctx,
+		http.MethodGet,
+		metaModerationCategoriesPath,
+		nil,
+		&data,
+	)
+	return
+}

--- a/projectapi/moderation.go
+++ b/projectapi/moderation.go
@@ -1,0 +1,60 @@
+package projectapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/uploadcare/uploadcare-go/v2/internal/codec"
+)
+
+const moderationThresholdsPathFmt = "/projects/%s/moderation/thresholds/"
+
+func (s service) GetModerationThresholds(
+	ctx context.Context,
+	pubKey string,
+) (data ModerationThresholds, err error) {
+	if err = validatePubKey(pubKey); err != nil {
+		return
+	}
+	err = s.svc.ResourceOp(
+		ctx,
+		http.MethodGet,
+		moderationThresholdsPath(pubKey),
+		nil,
+		&data,
+	)
+	return
+}
+
+func (s service) SetModerationThresholds(
+	ctx context.Context,
+	pubKey string,
+	thresholds []ModerationThresholdParams,
+) (data ModerationThresholds, err error) {
+	if err = validatePubKey(pubKey); err != nil {
+		return
+	}
+	err = s.svc.ResourceOp(
+		ctx,
+		http.MethodPut,
+		moderationThresholdsPath(pubKey),
+		setModerationThresholdsParams(thresholds),
+		&data,
+	)
+	return
+}
+
+type setModerationThresholdsParams []ModerationThresholdParams
+
+func (p setModerationThresholdsParams) EncodeReq(req *http.Request) error {
+	if p == nil {
+		p = setModerationThresholdsParams{}
+	}
+	return codec.EncodeReqBody(p, req)
+}
+
+func moderationThresholdsPath(pubKey string) string {
+	return fmt.Sprintf(moderationThresholdsPathFmt, url.PathEscape(pubKey))
+}

--- a/projectapi/projectapi.go
+++ b/projectapi/projectapi.go
@@ -1,4 +1,4 @@
-// Package projectapi is the Uploadcare Project API (projects, secret keys, and usage metrics).
+// Package projectapi is the Uploadcare Project API.
 package projectapi
 
 import (
@@ -17,13 +17,17 @@ type Project struct {
 }
 
 type ProjectFeatures struct {
-	GifToVideoConversion *FeatureToggle     `json:"gif_to_video_conversion,omitempty"`
-	MimeTypeFiltering    *MimeTypeFiltering `json:"mime_type_filtering,omitempty"`
-	TeamMembers          *TeamMembers       `json:"team_members,omitempty"`
-	Uploads              *UploadSettings    `json:"uploads,omitempty"`
-	VideoProcessing      *FeatureToggle     `json:"video_processing,omitempty"`
-	MalwareProtection    *FeatureToggle     `json:"malware_protection,omitempty"`
-	SVGValidation        *FeatureToggle     `json:"svg_validation,omitempty"`
+	GifToVideoConversion     *FeatureToggle          `json:"gif_to_video_conversion,omitempty"`
+	MimeTypeFiltering        *MimeTypeFiltering      `json:"mime_type_filtering,omitempty"`
+	TeamMembers              *TeamMembers            `json:"team_members,omitempty"`
+	Uploads                  *UploadSettings         `json:"uploads,omitempty"`
+	VideoProcessing          *FeatureToggle          `json:"video_processing,omitempty"`
+	MalwareProtection        *FeatureToggle          `json:"malware_protection,omitempty"`
+	SVGValidation            *FeatureToggle          `json:"svg_validation,omitempty"`
+	UnsafeContentDetection   *UnsafeContentDetection `json:"unsafe_content_detection,omitempty"`
+	AdaptiveBitrateStreaming *FeatureToggle          `json:"adaptive_bitrate_streaming,omitempty"`
+	DocumentConversion       *FeatureToggle          `json:"document_conversion,omitempty"`
+	EXIFMetadataRemoval      *FeatureToggle          `json:"exif_metadata_removal,omitempty"`
 }
 
 type FeatureToggle struct {
@@ -31,9 +35,22 @@ type FeatureToggle struct {
 }
 
 type MimeTypeFiltering struct {
-	MimeTypes              []string `json:"mime_types,omitempty"`
-	IsMimeFilteringEnabled *bool    `json:"is_mime_filtering_enabled,omitempty"`
+	MimeTypes []string `json:"mime_types,omitempty"`
+	IsEnabled *bool    `json:"is_enabled,omitempty"`
 }
+
+type UnsafeContentDetection struct {
+	IsEnabled      *bool              `json:"is_enabled,omitempty"`
+	AutoModeration AutoModerationMode `json:"auto_moderation,omitempty"`
+}
+
+type AutoModerationMode string
+
+const (
+	AutoModerationDisabled    AutoModerationMode = "disabled"
+	AutoModerationEnabled     AutoModerationMode = "enabled"
+	AutoModerationRemoveFiles AutoModerationMode = "remove_files"
+)
 
 type TeamMembers struct {
 	TeamSize int `json:"team_size,omitempty"`
@@ -111,4 +128,44 @@ type CombinedUsageDataPoint struct {
 	Traffic    int64  `json:"traffic"`
 	Storage    int64  `json:"storage"`
 	Operations int64  `json:"operations"`
+}
+
+type ModerationThresholdFileType string
+
+const (
+	ModerationThresholdFileTypeImage ModerationThresholdFileType = "image"
+)
+
+type ModerationThreshold struct {
+	CategoryID          int                         `json:"category_id"`
+	FileType            ModerationThresholdFileType `json:"file_type"`
+	ThresholdPercentage string                      `json:"threshold_percentage"`
+	CreatedAt           string                      `json:"created_at,omitempty"`
+	UpdatedAt           string                      `json:"updated_at,omitempty"`
+}
+
+type ModerationThresholdParams struct {
+	CategoryID          int                         `json:"category_id"`
+	FileType            ModerationThresholdFileType `json:"file_type"`
+	ThresholdPercentage string                      `json:"threshold_percentage"`
+}
+
+type ModerationThresholds struct {
+	Thresholds []ModerationThreshold `json:"thresholds"`
+}
+
+type MimeTypes struct {
+	MimeTypes []string `json:"mime_types"`
+}
+
+type ModerationCategories struct {
+	Categories []ModerationCategory `json:"categories"`
+}
+
+type ModerationCategory struct {
+	ID          int    `json:"id"`
+	ParentID    *int   `json:"parent_id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Level       int    `json:"level"`
 }

--- a/projectapi/service.go
+++ b/projectapi/service.go
@@ -22,6 +22,12 @@ type Service interface {
 
 	GetUsage(ctx context.Context, pubKey string, params UsageDateRange) (UsageMetricsCombined, error)
 	GetUsageMetric(ctx context.Context, pubKey string, metric UsageMetricName, params UsageDateRange) (UsageMetric, error)
+
+	GetModerationThresholds(ctx context.Context, pubKey string) (ModerationThresholds, error)
+	SetModerationThresholds(ctx context.Context, pubKey string, thresholds []ModerationThresholdParams) (ModerationThresholds, error)
+
+	ListMimeTypes(ctx context.Context) (MimeTypes, error)
+	ListModerationCategories(ctx context.Context) (ModerationCategories, error)
 }
 
 type service struct {

--- a/projectapi/service_test.go
+++ b/projectapi/service_test.go
@@ -117,6 +117,80 @@ func TestGetProject(t *testing.T) {
 	})
 }
 
+func TestProjectFeatureJSON(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	tests := []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{
+			name: "unmarshal_feature_fields",
+			run: func(t *testing.T) {
+				var data Project
+				require.NoError(t, json.Unmarshal([]byte(`{
+					"features": {
+						"mime_type_filtering": {
+							"mime_types": ["image/jpeg"],
+							"is_enabled": true
+						},
+						"unsafe_content_detection": {
+							"is_enabled": true,
+							"auto_moderation": "remove_files"
+						},
+						"adaptive_bitrate_streaming": {
+							"is_enabled": false
+						},
+						"document_conversion": {
+							"is_enabled": true
+						},
+						"exif_metadata_removal": {
+							"is_enabled": false
+						}
+					}
+				}`), &data))
+
+				require.NotNil(t, data.Features)
+				require.NotNil(t, data.Features.MimeTypeFiltering)
+				require.NotNil(t, data.Features.MimeTypeFiltering.IsEnabled)
+				assert.True(t, *data.Features.MimeTypeFiltering.IsEnabled)
+				assert.Equal(t, []string{"image/jpeg"}, data.Features.MimeTypeFiltering.MimeTypes)
+				require.NotNil(t, data.Features.UnsafeContentDetection)
+				assert.Equal(t, AutoModerationRemoveFiles, data.Features.UnsafeContentDetection.AutoModeration)
+				assert.NotNil(t, data.Features.AdaptiveBitrateStreaming)
+				assert.NotNil(t, data.Features.DocumentConversion)
+				assert.NotNil(t, data.Features.EXIFMetadataRemoval)
+			},
+		},
+		{
+			name: "marshal_mime_type_filtering",
+			run: func(t *testing.T) {
+				raw, err := json.Marshal(ProjectFeatures{
+					MimeTypeFiltering: &MimeTypeFiltering{
+						MimeTypes: []string{"image/jpeg"},
+						IsEnabled: &enabled,
+					},
+				})
+				require.NoError(t, err)
+				assert.JSONEq(t, `{
+					"mime_type_filtering": {
+						"mime_types": ["image/jpeg"],
+						"is_enabled": true
+					}
+				}`, string(raw))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.run(t)
+		})
+	}
+}
+
 func TestUpdateProject(t *testing.T) {
 	t.Parallel()
 
@@ -149,6 +223,116 @@ func TestDeleteProject(t *testing.T) {
 		err := svc.Delete(context.Background(), testPubKey)
 		require.NoError(t, err)
 	})
+}
+
+func TestModerationThresholds(t *testing.T) {
+	t.Parallel()
+
+	responseThresholds := func(params []ModerationThresholdParams) ModerationThresholds {
+		thresholds := make([]ModerationThreshold, 0, len(params))
+		for _, p := range params {
+			thresholds = append(thresholds, ModerationThreshold{
+				CategoryID:          p.CategoryID,
+				FileType:            p.FileType,
+				ThresholdPercentage: p.ThresholdPercentage,
+				CreatedAt:           "2024-12-30T11:24:28.604307Z",
+				UpdatedAt:           "2024-12-30T12:14:02.028743Z",
+			})
+		}
+		return ModerationThresholds{Thresholds: thresholds}
+	}
+
+	tests := []struct {
+		name    string
+		method  string
+		call    func(Service) (ModerationThresholds, error)
+		handler func(*testing.T, http.ResponseWriter, *http.Request)
+		check   func(*testing.T, ModerationThresholds)
+	}{
+		{
+			name:   "get",
+			method: http.MethodGet,
+			call: func(svc Service) (ModerationThresholds, error) {
+				return svc.GetModerationThresholds(context.Background(), testPubKey)
+			},
+			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				uctest.RespondJSON(t, w, ModerationThresholds{
+					Thresholds: []ModerationThreshold{
+						{
+							CategoryID:          4,
+							FileType:            ModerationThresholdFileTypeImage,
+							ThresholdPercentage: "37.00",
+							CreatedAt:           "2024-12-30T11:24:28.604307Z",
+							UpdatedAt:           "2024-12-30T12:14:02.028743Z",
+						},
+					},
+				})
+			},
+			check: func(t *testing.T, data ModerationThresholds) {
+				require.Len(t, data.Thresholds, 1)
+				assert.Equal(t, 4, data.Thresholds[0].CategoryID)
+				assert.Equal(t, ModerationThresholdFileTypeImage, data.Thresholds[0].FileType)
+				assert.Equal(t, "37.00", data.Thresholds[0].ThresholdPercentage)
+			},
+		},
+		{
+			name:   "set",
+			method: http.MethodPut,
+			call: func(svc Service) (ModerationThresholds, error) {
+				return svc.SetModerationThresholds(context.Background(), testPubKey, []ModerationThresholdParams{
+					{CategoryID: 4, FileType: ModerationThresholdFileTypeImage, ThresholdPercentage: "30.0"},
+					{CategoryID: 5, FileType: ModerationThresholdFileTypeImage, ThresholdPercentage: "45.0"},
+				})
+			},
+			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				body := uctest.ReadBody(t, r)
+				assert.NotContains(t, string(body), "created_at")
+				assert.NotContains(t, string(body), "updated_at")
+
+				var params []ModerationThresholdParams
+				require.NoError(t, json.Unmarshal(body, &params))
+				require.Len(t, params, 2)
+				assert.Equal(t, 4, params[0].CategoryID)
+				assert.Equal(t, ModerationThresholdFileTypeImage, params[0].FileType)
+				assert.Equal(t, "30.0", params[0].ThresholdPercentage)
+
+				uctest.RespondJSON(t, w, responseThresholds(params))
+			},
+			check: func(t *testing.T, data ModerationThresholds) {
+				require.Len(t, data.Thresholds, 2)
+				assert.Equal(t, "45.0", data.Thresholds[1].ThresholdPercentage)
+			},
+		},
+		{
+			name:   "set_empty",
+			method: http.MethodPut,
+			call: func(svc Service) (ModerationThresholds, error) {
+				return svc.SetModerationThresholds(context.Background(), testPubKey, nil)
+			},
+			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				assert.JSONEq(t, `[]`, string(uctest.ReadBody(t, r)))
+				uctest.RespondJSON(t, w, ModerationThresholds{})
+			},
+			check: func(t *testing.T, data ModerationThresholds) {
+				assert.Empty(t, data.Thresholds)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			withProjectAPIService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.method, r.Method)
+				assert.Equal(t, "/projects/"+testPubKey+"/moderation/thresholds/", r.URL.Path)
+				tt.handler(t, w, r)
+			}), func(svc Service) {
+				data, err := tt.call(svc)
+				require.NoError(t, err)
+				tt.check(t, data)
+			})
+		})
+	}
 }
 
 func TestListSecrets(t *testing.T) {
@@ -265,6 +449,67 @@ func TestGetUsageMetric(t *testing.T) {
 	})
 }
 
+func TestMeta(t *testing.T) {
+	t.Parallel()
+
+	parentID := 7
+	tests := []struct {
+		name    string
+		path    string
+		call    func(*testing.T, Service)
+		handler func(*testing.T, http.ResponseWriter, *http.Request)
+	}{
+		{
+			name: "mime_types",
+			path: "/meta/mime/types/",
+			call: func(t *testing.T, svc Service) {
+				data, err := svc.ListMimeTypes(context.Background())
+				require.NoError(t, err)
+				assert.Equal(t, []string{"application/cbor", "image/jpeg"}, data.MimeTypes)
+			},
+			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				uctest.RespondJSON(t, w, MimeTypes{
+					MimeTypes: []string{"application/cbor", "image/jpeg"},
+				})
+			},
+		},
+		{
+			name: "moderation_categories",
+			path: "/meta/moderation/categories/",
+			call: func(t *testing.T, svc Service) {
+				data, err := svc.ListModerationCategories(context.Background())
+				require.NoError(t, err)
+				require.Len(t, data.Categories, 2)
+				assert.Equal(t, "Alcohol", data.Categories[0].Name)
+				require.NotNil(t, data.Categories[1].ParentID)
+				assert.Equal(t, parentID, *data.Categories[1].ParentID)
+			},
+			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				uctest.RespondJSON(t, w, ModerationCategories{
+					Categories: []ModerationCategory{
+						{ID: 7, Name: "Alcohol", Description: "", Level: 1},
+						{ID: 8, ParentID: &parentID, Name: "Alcoholic Beverages", Description: "Description", Level: 2},
+					},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			withProjectAPIService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, tt.path, r.URL.Path)
+				assert.Empty(t, r.URL.RawQuery)
+				tt.handler(t, w, r)
+			}), func(svc Service) {
+				tt.call(t, svc)
+			})
+		})
+	}
+}
+
 func TestPathValidation(t *testing.T) {
 	t.Parallel()
 
@@ -330,6 +575,22 @@ func TestPathValidation(t *testing.T) {
 				return err
 			},
 			wantErr: ErrInvalidUsageMetric,
+		},
+		{
+			name: "get_moderation_thresholds_slash_pub_key",
+			call: func(svc Service) error {
+				_, err := svc.GetModerationThresholds(context.Background(), "bad/key")
+				return err
+			},
+			wantErr: ErrInvalidPubKey,
+		},
+		{
+			name: "set_moderation_thresholds_empty_pub_key",
+			call: func(svc Service) error {
+				_, err := svc.SetModerationThresholds(context.Background(), "", nil)
+				return err
+			},
+			wantErr: ErrInvalidPubKey,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Update Project API feature structs for the April 2026 schema, including the `mime_type_filtering.is_enabled` rename and new billing-related feature fields.
- Add moderation threshold endpoints with separate request and response threshold types so server-owned timestamps are not sent in PUT requests.
- Add Project API meta endpoints for MIME types and moderation categories.

## Validation

- `go test ./projectapi`
- `go list ./... | grep -v '/test$' | xargs go test`

Note: the full `go test ./...` still requires integration credentials for the `test` package (`SECRET_KEY` and `PUBLIC_KEY`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added moderation thresholds management (get/set) for projects
  * Added APIs to list supported MIME types and moderation categories
  * Expanded project features with new toggles: GIF→video conversion, malware protection, SVG validation, unsafe content detection, adaptive bitrate streaming, document conversion, EXIF metadata removal

* **Tests**
  * Added coverage for project feature JSON, moderation thresholds, meta endpoints, and path validation

* **Chores**
  * Updated changelog to reflect expanded Project API capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uploadcare/uploadcare-go/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->